### PR TITLE
Ensure we always run erfa generator when creating the package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE.rst
 include README.rst
 include pyproject.toml
 include setup.cfg
+include erfa_generator.py
 
 recursive-include erfa *.c *.h *.templ
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-
+import sys
 import setuptools
+import subprocess
 
 
 ERFAPKGDIR = os.path.abspath(os.path.dirname(__file__))
@@ -30,14 +31,11 @@ class NumpyExtension(setuptools.Extension):
 
 
 def get_extensions():
-    if not os.path.exists(os.path.join('erfa', 'ufunc.c')):
-        import sys
-        import subprocess
-        cmd = [
-            sys.executable, os.path.join(ERFAPKGDIR, 'erfa_generator.py'),
-            ERFA_SRC, '--quiet',
-        ]
-        subprocess.run(cmd, check=True)
+    cmd = [
+        sys.executable, os.path.join(ERFAPKGDIR, 'erfa_generator.py'),
+        ERFA_SRC, '--quiet',
+    ]
+    subprocess.run(cmd, check=True)
 
     sources = [os.path.join(ERFAPKGDIR, 'erfa', fn)
                for fn in ("ufunc.c", "pav2pv.c", "pv2pav.c")]


### PR DESCRIPTION
Even if files are present, they may be out of date. To get this to work, we have to ensure erfa_generator is included in the manifest.

@avalentino - since you added the check to `setup.py`, do you agree it is OK to leave it out?

fixes #11