### PR TITLE
Setup testing with apt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,11 @@ jobs:
           env: TOXENV=build_docs
 
         # We try our apt test on the big-endian s390x architecture,
-        # to check that things work there as well.
+        # to check that things work there as well. We also test that
+        # we can use a system library.
         - name: install with apt
           stage: Comprehensive tests
+          arch: s390x
           language: c
           env: SETUP_METHOD='apt'
                PYERFA_USE_SYSTEM_LIBERFA=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
 
         # Also allow tests without tox, getting our packages using apt;
         # Here, we still need pip to install pyerfa.
-        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy'
+        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy liberfa-dev'
 
 jobs:
     include:
@@ -56,6 +56,7 @@ jobs:
           stage: Comprehensive tests
           language: c
           env: SETUP_METHOD='apt'
+               PYERFA_USE_SYSTEM_LIBERFA=1
 
 install:
     - if [[ $SETUP_METHOD == 'tox' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,23 @@ stages:
 
 env:
     global:
+        # The following versions are the 'default' for tests, unless
+        # overridden underneath. They are defined here in order to save having
+        # to repeat them for all configurations.
+        - SETUP_METHOD='tox'
+
         # The following three variables are for tox. TOXENV is a standard
         # variable that tox uses to determine the environment to run,
         # TOXARGS are arguments passed to tox, and TOXPOSARGS are arguments
         # that tox passes through to the {posargs} indicator in tox.ini.
         # The latter can be used for example to pass arguments to pytest.
+        - TOXENV='test'
         - TOXARGS='-v'
         - TOXPOSARGS=''
+
+        # Also allow tests without tox, getting our packages using apt;
+        # Here, we still need pip to install pyerfa.
+        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy'
 
 jobs:
     include:
@@ -40,8 +50,29 @@ jobs:
           python: 3.8
           env: TOXENV=build_docs
 
+        # We try our apt test on the big-endian s390x architecture,
+        # to check that things work there as well.
+        - name: install with apt
+          stage: Comprehensive tests
+          language: c
+          env: SETUP_METHOD='apt'
+
 install:
-    - pip install tox;
+    - if [[ $SETUP_METHOD == 'tox' ]]; then
+        pip install tox;
+      else
+        curl https://ftp-master.debian.org/keys/archive-key-10.asc | sudo apt-key add -;
+        echo "deb http://ftp.us.debian.org/debian testing main" | sudo tee -a /etc/apt/sources.list;
+        sudo apt-get -qq update;
+        sudo apt-get install -y --no-install-recommends ${APT_DEPENDENCIES};
+      fi
 
 script:
-    - tox $TOXARGS -- $TOXPOSARGS;
+    - if [[ $SETUP_METHOD == 'tox' ]]; then
+        tox $TOXARGS -- $TOXPOSARGS;
+      else
+        python3 -m venv --system-site-packages tests;
+        source tests/bin/activate;
+        pip3 install --no-deps --editable .[test];
+        pytest-3;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,6 @@ script:
         python3 -m venv --system-site-packages tests;
         source tests/bin/activate;
         pip3 install --no-deps --editable .[test];
-        nm -u erfa/ufunc.cpython-*.so | grep eraA2af;
+        (nm -u erfa/ufunc.cpython-*.so | grep eraA2af) || exit 1;
         pytest-3;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,5 +74,6 @@ script:
         python3 -m venv --system-site-packages tests;
         source tests/bin/activate;
         pip3 install --no-deps --editable .[test];
+        nm erfa/ufunc.cpython-*.so | grep eraA2af;
         pytest-3;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,6 @@ script:
         python3 -m venv --system-site-packages tests;
         source tests/bin/activate;
         pip3 install --no-deps --editable .[test];
-        nm erfa/ufunc.cpython-*.so | grep eraA2af;
+        nm -u erfa/ufunc.cpython-*.so | grep eraA2af;
         pytest-3;
       fi

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ def get_extensions():
 
     libraries = []
 
-    if (int(os.environ.get('PYERFA_USE_SYSTEM_ERFA', 0)) or
-            int(os.environ.get('PYERFA_USE_SYSTEM_ALL', 0))):
+    if int(os.environ.get('PYERFA_USE_SYSTEM_LIBERFA', 0)):
         libraries.append('erfa')
     else:
         # get all of the .c files in the liberfa/erfa/src directory


### PR DESCRIPTION
fixes #14 

Set up testing with system library, which for me was easiest to do with the pre-build library provided by debian. Thought one might as well test big-endian at the same time.
- [X] Setup test using apt.
- [X] Let it use system library
- [X] Verify that system library is in fact used. 
- [X] Maybe move to a big-endian architecture