### PR TITLE
Setup RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  image: latest
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+formats: []


### PR DESCRIPTION
Just imported the project on RTD.
This PR is for the `.readthedocs.yml` configuration file.

I have also made a request to the rtd support team to enable builds on PRs, so we soon should be test the setup.

Edit: @astrofrog , sorry I've just realized that admin permissions on the github project are required to properly setup the rtd webhook,  Can you please give a look to https://readthedocs.org/dashboard/pyerfa/integrations/