### PR TITLE
Added initial Azure pipelines configuration for auto-release

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -15,6 +15,13 @@ PGP keys set up. Then, push the tag to GitHub, e.g.::
 
     git push upstream v0.1
 
-and the build should happen automatically on Azure pipelines. See
-the [OpenAstronomy Azure Pipelines Templates Documentation](https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html)
-for more details.
+and the build should happen automatically on Azure pipelines. You can
+follow the progress of the build here:
+
+https://dev.azure.com/liberfa/pyerfa/_build
+
+If there are any failures, you can always delete the tag, fix the
+issues, tag the release again, and push the tag to GitHub.
+
+See the `OpenAstronomy Azure Pipelines Templates Documentation <https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html>`_
+for more details about the Azure Pipelines set-up.

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -1,0 +1,20 @@
+Release instructions
+====================
+
+Once the package is ready to release, use ``git tag`` to tag the
+release::
+
+    git tag -m <version> <version>
+
+e.g::
+
+    git tag -m v0.1 v0.1
+
+You can also include the ``-s`` flag to sign the tag if you have
+PGP keys set up. Then, push the tag to GitHub, e.g.::
+
+    git push upstream v0.1
+
+and the build should happen automatically on Azure pipelines. See
+the [OpenAstronomy Azure Pipelines Templates Documentation](https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html)
+for more details.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,36 @@
+variables:
+  CIBW_BUILD: cp36-* cp37-* cp38-*
+
+resources:
+  repositories:
+  - repository: OpenAstronomy
+    type: github
+    endpoint: liberfa
+    name: OpenAstronomy/azure-pipelines-templates
+    ref: master
+
+trigger:
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - 'v*'
+
+jobs:
+
+# The following is the configuration to automatically release a new version
+# to PyPI if a tag is pushed - for more details, see:
+# https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html
+
+- template: publish.yml@OpenAstronomy
+  parameters:
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+      pypi_connection_name: 'pypi_endpoint'
+    test_extras: test
+    test_command: pytest --pyargs erfa
+    targets:
+    - sdist
+    - wheels_linux
+    - wheels_macos
+    - wheels_windows


### PR DESCRIPTION
The way this works is that the wheel build and testing happens for every commit and PR, but the publication to PyPI happens only if a tag is pushed to the main repository. Let me know if the release instructions are clear enough. Note that this builds both the sdist and the wheels.

See https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html if you are interested in the pipeline settings. I'll be setting up the authentication on Azure Pipelines shortly, but for now the CI will run (it just would fail at the publishing step if this were building a tag)

Fixes #8 