### PR TITLE
Expose version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 # Other generated files
 MANIFEST
 erfa/core.py
+erfa/version.py
 
 # Sphinx
 _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+python: 3.8
+
 # We need a full clone to make sure setuptools_scm works properly
 git:
     depth: false
@@ -35,20 +37,29 @@ env:
         - TOXPOSARGS=''
 
         # Also allow tests without tox, getting our packages using apt;
-        # Here, we still need pip to install pyerfa.
-        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy liberfa-dev'
+        # We include liberfa-dev so we can test using a system library,
+        # and python3-astropy to run a few tests that rely on Time.
+        # We need venv for a test environment and pip to install pyerfa itself.
+        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy liberfa-dev python3-astropy'
 
 jobs:
     include:
         - name: Tests that all the basics are covered.
           stage: Initial tests
-          python: 3.8
           env: TOXENV=test
 
         - name: Documentation build
           stage: Comprehensive tests
-          python: 3.8
           env: TOXENV=build_docs
+
+        - name: Test with oldest supported versions of our dependencies
+          stage: Comprehensive tests
+          python: 3.6
+          env: TOXENV=test-oldestdeps
+
+        - name: Test with development versions of our dependencies
+          stage: Comprehensive tests
+          env: TOXENV=test-devdeps
 
         # We try our apt test on the big-endian s390x architecture,
         # to check that things work there as well. We also test that

--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,14 @@ The package can be installed from the package directory using a simple::
 
   $ pip install .
 
-and similarly a Python_ wheel_ can be created with::
+and similarly a wheel_ can be created with::
 
   $ pip wheel .
+
+.. note:: If you already have the C library ``liberfa`` on your
+  system, you can use that by setting environment variable
+  ``PYERFA_USE_SYSTEM_LIBERFA=1``.
+
 
 .. _wheel: https://github.com/pypa/wheel
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,1 +1,4 @@
 .. automodapi:: erfa
+
+.. automodapi:: erfa.version
+   :include-all-objects:

--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -4,3 +4,4 @@ from .core import *
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,
                     dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
 from .helpers import leap_seconds
+from .version import version as __version__

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -32,9 +32,7 @@ from . import ufunc
 
 __all__ = ['ErfaError', 'ErfaWarning',
            {{ funcs|map(attribute='pyname')|surround("'","'")|join(", ") }},
-           {{ constants|map(attribute='name')|surround("'","'")|join(", ") }},
-           # TODO: delete the functions below when they can get auto-generated
-           'version', 'version_major', 'version_minor', 'version_micro', 'sofa_version']
+           {{ constants|map(attribute='name')|surround("'","'")|join(", ") }}]
 
 
 class ErfaError(ValueError):
@@ -197,50 +195,3 @@ STATUS_CODES['{{ func.pyname }}'] = {{ stat.doc_info.statuscodes|string }}
 {% endfor %}
 {% endif -%}
 {% endfor -%}
-
-
-# TODO: delete the functions below when they can get auto-generated
-# (current machinery doesn't support returning strings or non-status-codes)
-def version():
-    """
-    Returns the package version
-    as defined in configure.ac
-    in string format
-    """
-    return "1.6.0"
-
-
-def version_major():
-    """
-    Returns the package major version
-    as defined in configure.ac
-    as integer
-    """
-    return 1
-
-
-def version_minor():
-    """
-    Returns the package minor version
-    as defined in configure.ac
-    as integer
-    """
-    return 6
-
-
-def version_micro():
-    """
-    Returns the package micro version
-    as defined in configure.ac
-    as integer
-    """
-    return 0
-
-
-def sofa_version():
-    """
-    Returns the corresponding SOFA version
-    as defined in configure.ac
-    in string format
-    """
-    return "20190722"

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -19,6 +19,22 @@ except ImportError:
             pass
 
 
+class TestVersion:
+    def test_basic(self):
+        assert hasattr(erfa.version, 'erfa_version')
+        erfa_version = erfa.version.erfa_version
+        assert isinstance(erfa_version, str)
+        assert len(erfa_version.split('.')) == 3
+
+    def test_sofa_version(self):
+        assert hasattr(erfa.version, 'sofa_version')
+        sofa_version = erfa.version.sofa_version
+        assert isinstance(sofa_version, str)
+        assert len(sofa_version) == 8
+        # Sorry, future 22nd century person, you may have to adjust!
+        assert sofa_version.startswith('20')
+
+
 def test_erfa_wrapper():
     """
     Runs a set of tests that mostly make sure vectorization is

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -717,6 +717,8 @@ PyMODINIT_FUNC PyInit_ufunc(void)
 {
     /* module and its dict */
     PyObject *m, *d;
+    /* version information */
+    PyObject *erfa_version, *sofa_version;
     /* structured dtypes and their definition */
     PyObject *dtype_def;
     PyArray_Descr *dt_double = NULL, *dt_int = NULL;
@@ -746,7 +748,23 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     if (d == NULL) {
         goto fail;
     }
-
+    /*
+     * Make the version information available in the module.
+     * Note that this gets run every time _erfa is imported,
+     * hence if the library is provided by the system rather
+     * than bundled with astropy, one correctly gets the version
+     * information from the system library.
+     */
+    erfa_version = PyUnicode_FromString(eraVersion());
+    sofa_version = PyUnicode_FromString(eraSofaVersion());
+    if (erfa_version == NULL || sofa_version == NULL) {
+        goto fail;
+    }
+    PyDict_SetItemString(d, "erfa_version", erfa_version);
+    PyDict_SetItemString(d, "sofa_version", sofa_version);
+    /*
+     * Get ready for arrays and ufuncs
+     */
     import_array();
     import_umath();
     /*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
-requires = ["setuptools", "wheel", "jinja2==2.10.3", "oldest-supported-numpy"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel",
+            "jinja2>=2.10.3", "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pyerfa
-version=1.7.0
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
 license = BSD 3-Clause License
@@ -25,6 +24,7 @@ classifiers =
 packages = find:
 requires = numpy
 zip_safe = False
+setup_requires = setuptools_scm
 install_requires = numpy>=1.16
 python_requires = >=3.6
 

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,28 @@ def get_extensions():
 
 
 VERSION_TEMPLATE = """
+'''Wrapper, ERFA and SOFA version information.'''
+
+# Set the version numbers a bit indirectly, so that Sphinx can pick up
+# up the docstrings and list the values.
+from . import ufunc
+
+
+erfa_version = ufunc.erfa_version
+'''Version of the C ERFA library that is wrapped.'''
+
+sofa_version = ufunc.sofa_version
+'''Version of the SOFA library the ERFA library is based on.'''
+
+del ufunc
+
 # Note that we need to fall back to the hard-coded version if either
 # setuptools_scm can't be imported or setuptools_scm can't determine the
 # version, so we catch the generic 'Exception'.
 try:
     from setuptools_scm import get_version
     version = get_version(root='..', relative_to=__file__)
+    '''Version of the python wrappers.'''
 except Exception:
     version = '{version}'
 else:

--- a/setup.py
+++ b/setup.py
@@ -65,4 +65,20 @@ def get_extensions():
     return [erfa_ext]
 
 
-setuptools.setup(ext_modules=get_extensions())
+VERSION_TEMPLATE = """
+# Note that we need to fall back to the hard-coded version if either
+# setuptools_scm can't be imported or setuptools_scm can't determine the
+# version, so we catch the generic 'Exception'.
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+except Exception:
+    version = '{version}'
+else:
+    del get_version
+""".lstrip()
+
+setuptools.setup(use_scm_version={
+    'write_to': os.path.join('erfa', 'version.py'),
+    'write_to_template': VERSION_TEMPLATE},
+      ext_modules=get_extensions())

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 isolated_build = true
+indexserver =
+    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 
@@ -34,7 +36,7 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
     oldestdeps: numpy==1.17.*
-    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
+    devdeps: :NIGHTLY:numpy
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
This is a port of https://github.com/astropy/astropy/pull/9324/commits/e2e285a3512942141875141b6b30bb5c4ae00002, exposing the ERFA and SOFA information. Since we now have our own package, it seemed most logical to expose these inside a new `version` module - and to have that I now use `setuptools_scm` (cc @astrofrog, just to be sure I use it correctly). That solves another thing on the list of #23...

@eteq - I only expose `erfa_version` and `sofa_version`, not the erfa major, minor and micro, since I felt those were not all that useful. I also removed the version functions from `core`, since having a new package would seem reason enough to clean that up (will have to deprecate them in `astropy/_erfa`, I guess).

Since there was a missing link in `README.rst` in building the docs, I took the opportunity to mention how to install using system libraries. Another one off the list in #23...