### PR TITLE
Set up versions with last digit a pyerfa fix number.

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -8,7 +8,13 @@ release::
 
 e.g::
 
-    git tag -m v0.1 v0.1
+    git tag -m v1.7.0 v1.7.0
+
+Here, the version number should generally be the same as that of
+the erfa library that is included (and you should make sure the
+git submodule ``liberfa/erfa`` is at the correct tag as well).
+If there is a need for just the wrappers to be updated, add a
+fourth number to the release (e.g., ``1.7.0.1``).
 
 You can also include the ``-s`` flag to sign the tag if you have
 PGP keys set up. Then, push the tag to GitHub, e.g.::

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 class TestVersion:
-    def test_basic(self):
+    def test_erfa_version(self):
         assert hasattr(erfa.version, 'erfa_version')
         erfa_version = erfa.version.erfa_version
         assert isinstance(erfa_version, str)
@@ -33,6 +33,14 @@ class TestVersion:
         assert len(sofa_version) == 8
         # Sorry, future 22nd century person, you may have to adjust!
         assert sofa_version.startswith('20')
+
+    def test_version(self):
+        assert hasattr(erfa, '__version__')
+        version = erfa.__version__
+        assert version is erfa.version.version
+        # Oops, we had the wrong version for quite a while...
+        assert (erfa.version.erfa_version == '1.6.0' and version.startswith('1.7.0')
+                or version.startswith(erfa.version.erfa_version))
 
 
 def test_erfa_wrapper():


### PR DESCRIPTION
My attempt at the four-digit version number. Still not sure I actually like it all that much, since the way things are set up, the python wrappers are fairly erfa-version agnostic.

Also note the hack in the tests to work around the fact that in our self-compilation we get the wrong erfa version number (see https://github.com/liberfa/erfa/issues/62)