### PR TITLE
Fix local docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,10 +51,9 @@ copyright = '2011–{0}, {1}'.format(datetime.utcnow().year, author)
 try:
     release = get_distribution(project).version
 except Exception:
-    import configparser
-    metadata = configparser.ConfigParser()
-    metadata.read('../setup.cfg')
-    release = metadata['metadata']['version']
+    # assume local build
+    sys.path.append('..')
+    from erfa import __version__ as release
 
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])


### PR DESCRIPTION
This small patch allows to build documentation locally (without installation) :

```
$ python3 setyp.py build_ext --inplace
$ make -C docs html
```

I it also handy for debian packaging