### PR TITLE
Add minimal usage instructions; refactor docs a little.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,10 @@ jobs:
         - name: Documentation build
           stage: Comprehensive tests
           env: TOXENV=build_docs
+          addons:
+              apt:
+                  packages:
+                      - graphviz
 
         - name: Test with oldest supported versions of our dependencies
           stage: Comprehensive tests

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,8 @@ context of Astropy_ project, into a standalone package.  It contains
 the ERFA_ C source code as a git submodule.  The wrapping is done
 with help of the Jinja2_ template engine.
 
-.. _Python: https://www.python.org/
-.. _ERFA: https://github.com/liberfa/erfa
-.. _Numpy: https://numpy.org/
-.. _Astropy: https://www.astropy.org
-.. _Jinja2: https://palletsprojects.com/p/jinja/
 
-
+.. Installation
 Installation instructions
 -------------------------
 
@@ -54,8 +49,58 @@ environment for you, with::
 
   $ tox -e test
 
+
+Usage
+-----
+
+The package can be imported as ``erfa`` which has all ERFA_ ufuncs wrapped with
+python code that tallies errors and warnings.  Also exposed are the constants
+defined by ERFA_ in `erfam.h
+<https://github.com/liberfa/erfa/blob/master/src/erfam.h>`_, as well
+as `numpy.dtype` corresponding to structures used by ERFA_.  Examples::
+
+  >>> import erfa
+  >>> erfa.jd2cal(2460000., [0, 1, 2, 3])
+  (array([2023, 2023, 2023, 2023], dtype=int32),
+   array([2, 2, 2, 2], dtype=int32),
+   array([24, 25, 26, 27], dtype=int32),
+   array([0.5, 0.5, 0.5, 0.5]))
+  >>> erfa.plan94(2460000., [0, 1, 2, 3], 1)
+  array([([ 0.09083713, -0.39041392, -0.21797389], [0.02192341, 0.00705449, 0.00149618]),
+         ([ 0.11260694, -0.38275202, -0.21613731], [0.02160375, 0.00826891, 0.00217806]),
+         ([ 0.13401992, -0.37387798, -0.21361622], [0.0212094 , 0.00947838, 0.00286503]),
+         ([ 0.15500031, -0.36379788, -0.21040601], [0.02073822, 0.01068061, 0.0035561 ])],
+        dtype={'names':['p','v'], 'formats':[('<f8', (3,)),('<f8', (3,))], 'offsets':[0,24], 'itemsize':48, 'aligned':True})
+  >>> erfa.dt_pv
+  dtype([('p', '<f8', (3,)), ('v', '<f8', (3,))], align=True)
+  >>> erfa.dt_eraLDBODY
+  dtype([('bm', '<f8'), ('dl', '<f8'), ('pv', '<f8', (2, 3))], align=True)
+  >>> erfa.DAYSEC
+  86400.0
+
+It is also possible to use the ufuncs directly, though then one has to
+deal with the warning and error states explicitly.  For instance, compare::
+
+  >>> erfa.jd2cal(-600000., [0, 1, 2, 3])
+  Traceback (most recent call last):
+  ...
+  ErfaError: ERFA function "jd2cal" yielded 4 of "unacceptable date (Note 1)"
+  >>> erfa.ufunc.jd2cal(-600000., [0, 1, 2, 3])
+  (array([-1, -1, -1, -1], dtype=int32),
+   ...,
+   array([-1, -1, -1, -1], dtype=int32))
+
+
 License
 -------
 
 PyERFA is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
+
+
+.. References
+.. _Python: https://www.python.org/
+.. _ERFA: https://github.com/liberfa/erfa
+.. _Numpy: https://numpy.org/
+.. _Astropy: https://www.astropy.org
+.. _Jinja2: https://palletsprojects.com/p/jinja/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,7 @@
 .. include:: ../README.rst
-   :end-before: Installation instructions
+   :end-before: .. Installation
+.. include:: ../README.rst
+   :start-after: .. References
 
 .. toctree::
    :maxdepth: 2

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,5 +3,7 @@ Quickstart
 ==========
 
 .. include:: ../README.rst
-   :start-after: .. _Astropy: https://www.astropy.org
+   :start-after: .. Installation
    :end-before: License
+.. include:: ../README.rst
+   :start-after: .. References

--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .core import *
-from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,
-                    dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
-from .helpers import leap_seconds
-from .version import version as __version__
+from .core import *  # noqa
+from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND,  # noqa
+                     dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
+from .helpers import leap_seconds  # noqa
+from .version import version as __version__  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 packages = find:
 requires = numpy
 zip_safe = False
+tests_require = pytest-doctestplus
 setup_requires = setuptools_scm
 install_requires = numpy>=1.16
 python_requires = >=3.6
@@ -31,14 +32,21 @@ python_requires = >=3.6
 [options.extras_require]
 test =
     pytest
+    pytest-doctestplus>=0.7
 docs =
     sphinx-astropy>=1.3
 
 [tool:pytest]
-minversion = 3.1
-testpaths = "erfa"
+minversion = 4.6
+testpaths = "erfa" "docs" "README.rst"
 doctest_plus = enabled
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    ELLIPSIS
+    FLOAT_CMP
+    IGNORE_EXCEPTION_DETAIL
 text_file_format = rst
+addopts = --doctest-rst
 xfail_strict = true
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -b html . _build/html
+    sphinx-build -W -b html . _build/html
 
 [testenv:linkcheck]
 changedir = docs


### PR DESCRIPTION
This came about mostly because I wanted to at least give a clue that the ufuncs are themselves wrapped in small bits of python code.