### PR TITLE
Do not run the code generator if PYERFA_USE_SYSTEM_LIBERFA=1 (Closes #38)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,9 @@ env:
         # We include liberfa-dev so we can test using a system library,
         # and python3-astropy to run a few tests that rely on Time.
         # We need venv for a test environment and pip to install pyerfa itself.
-        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy liberfa-dev python3-astropy'
+        # Here, we need to include python3-attr, since the version on bionic
+        # is too old.
+        - APT_DEPENDENCIES='python3-numpy python3-venv python3-pip python3-jinja2 python3-pytest-astropy liberfa-dev python3-astropy python3-attr'
 
 jobs:
     include:


### PR DESCRIPTION
The proposed change do not run the code generator (`erfa_generator.py`) when the user requires to use the system erfa library (`PYERFA_USE_SYSTEM_LIBERFA=1`).

NOTE: the change only works if the `core.py` and `ufunc.c` have been already generated in some way (e.g. if one uses the source tarball available on PyPi.io). It is not expected to work for a fresh git clone.
An error is raised if the `core.py` and `ufunc.c` files are not found.