### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@
 # See sphinx_astropy.conf for which values are set there.
 
 from datetime import datetime
-import sys
+import os, sys, time
 
 from pkg_resources import get_distribution
 
@@ -41,6 +41,9 @@ except ImportError:
 
 project = 'PyERFA'
 author = 'The PyERFA Developers'
+build_date = datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
 copyright = '2011–{0}, {1}'.format(datetime.utcnow().year, author)
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that pyerfa could not be built reproducibly. This is due to the documentation contained the current build date.

(This was originally filed in Debian as [#964958](https://bugs.debian.org/964958).)