### PR TITLE
Make titles of the docstrings more useful (plus cleanup)

### DIFF
--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -2,6 +2,6 @@
 
 from .core import *  # noqa
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND,  # noqa
-                     dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
+                    dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
 from .helpers import leap_seconds  # noqa
 from .version import version as __version__  # noqa

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -131,7 +131,7 @@ dt_bytes12 = numpy.dtype('S12')
 {% for func in funcs -%}
 def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }}):
     """
-    Wrapper for ERFA function ``{{ func.name }}``.
+    {{ func.doc.title }}
 
     Parameters
     ----------
@@ -147,14 +147,11 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
     Notes
     -----
-    The ERFA documentation is below.  {% if func.args_by_inout('inout') -%}
-    Note that, unlike the erfa routine,
+    Wraps ERFA function ``{{ func.name }}``.
+    {%- if func.args_by_inout('inout') %} Note that, unlike the erfa routine,
     the python wrapper does not change {{ func.args_by_inout('inout')
     | map(attribute='name')|join(', ') }} in-place.
-    {%- endif %}
-
-
-    ::
+    {%- endif %} The ERFA documentation is::
 
 {{ func.doc }}
     """

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -30,9 +30,12 @@ import numpy
 
 from . import ufunc
 
-__all__ = ['ErfaError', 'ErfaWarning',
-           {{ funcs|map(attribute='pyname')|surround("'","'")|join(", ") }},
-           {{ constants|map(attribute='name')|surround("'","'")|join(", ") }}]
+__all__ = [
+    'ErfaError', 'ErfaWarning',
+    {{ funcs | map(attribute='pyname') | surround("'","'")
+       | join(", ") | wordwrap(wrapstring='\n    ') }},
+    {{ constants | map(attribute='name') | surround("'","'")
+       | join(", ") | wordwrap(wrapstring='\n    ') }}]
 
 
 class ErfaError(ValueError):
@@ -78,41 +81,48 @@ def check_errwarn(statcodes, func_name):
             statcodes[statcodes == before] = after
             STATUS_CODES[func_name][after] = STATUS_CODES[func_name][before]
 
-    if numpy.any(statcodes<0):
-        # errors present - only report the errors.
+    if numpy.any(statcodes < 0):
+        # Errors present - only report the errors.
         if statcodes.shape:
-            statcodes = statcodes[statcodes<0]
+            statcodes = statcodes[statcodes < 0]
 
         errcodes = numpy.unique(statcodes)
 
-        errcounts = dict([(e, numpy.sum(statcodes==e)) for e in errcodes])
+        errcounts = dict([(e, numpy.sum(statcodes == e)) for e in errcodes])
 
         elsemsg = STATUS_CODES[func_name].get('else', None)
         if elsemsg is None:
-            errmsgs = dict([(e, STATUS_CODES[func_name].get(e, 'Return code ' + str(e))) for e in errcodes])
+            errmsgs = dict([(e, STATUS_CODES[func_name].get(
+                e, 'Return code ' + str(e))) for e in errcodes])
         else:
-            errmsgs = dict([(e, STATUS_CODES[func_name].get(e, elsemsg)) for e in errcodes])
+            errmsgs = dict([(e, STATUS_CODES[func_name].get(
+                e, elsemsg)) for e in errcodes])
 
-        emsg = ', '.join(['{0} of "{1}"'.format(errcounts[e], errmsgs[e]) for e in errcodes])
+        emsg = ', '.join(['{0} of "{1}"'.format(errcounts[e], errmsgs[e])
+                          for e in errcodes])
         raise ErfaError('ERFA function "' + func_name + '" yielded ' + emsg)
 
-    elif numpy.any(statcodes>0):
-        #only warnings present
+    elif numpy.any(statcodes > 0):
+        # Only warnings present.
         if statcodes.shape:
-            statcodes = statcodes[statcodes>0]
+            statcodes = statcodes[statcodes > 0]
 
         warncodes = numpy.unique(statcodes)
 
-        warncounts = dict([(w, numpy.sum(statcodes==w)) for w in warncodes])
+        warncounts = dict([(w, numpy.sum(statcodes == w)) for w in warncodes])
 
         elsemsg = STATUS_CODES[func_name].get('else', None)
         if elsemsg is None:
-            warnmsgs = dict([(w, STATUS_CODES[func_name].get(w, 'Return code ' + str(w))) for w in warncodes])
+            warnmsgs = dict([(w, STATUS_CODES[func_name].get(
+                w, 'Return code ' + str(w))) for w in warncodes])
         else:
-            warnmsgs = dict([(w, STATUS_CODES[func_name].get(w, elsemsg)) for w in warncodes])
+            warnmsgs = dict([(w, STATUS_CODES[func_name].get(
+                w, elsemsg)) for w in warncodes])
 
-        wmsg = ', '.join(['{0} of "{1}"'.format(warncounts[w], warnmsgs[w]) for w in warncodes])
-        warnings.warn('ERFA function "' + func_name + '" yielded ' + wmsg, ErfaWarning)
+        wmsg = ', '.join(['{0} of "{1}"'.format(warncounts[w], warnmsgs[w])
+                          for w in warncodes])
+        warnings.warn('ERFA function {!r} yielded {}'.format(func_name, wmsg),
+                      ErfaWarning)
 
 
 # <------------------------structured dtype conversion------------------------>
@@ -124,11 +134,13 @@ dt_bytes12 = numpy.dtype('S12')
 
 {% for constant in constants %}
 {{ constant.name }} = {{ constant.value }}
-"""{{ constant.doc|join(' ') }}"""
+"""{{ constant.doc|join(' ')|wordwrap() }}"""
 {%- endfor %}
 
 
-{% for func in funcs -%}
+{%- for func in funcs %}
+
+
 def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }}):
     """
     {{ func.doc.title }}
@@ -180,15 +192,21 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
      #}
     return {{ func.args_by_inout('inout|out|ret')|map(attribute='name')|join(', ') }}
 
-
-{#
+{#-
  # Define the status codes that this function returns.
  #}
-{%- if func.args_by_inout('stat') -%}
-{%- for stat in func.args_by_inout('stat') -%}
-{%- if stat.doc_info.statuscodes -%}
-STATUS_CODES['{{ func.pyname }}'] = {{ stat.doc_info.statuscodes|string }}
-{% endif %}
-{% endfor %}
-{% endif -%}
-{% endfor -%}
+{%- if func.args_by_inout('stat') %}
+{%- for stat in func.args_by_inout('stat') %}
+{%- if stat.doc_info.statuscodes %}
+
+
+STATUS_CODES['{{ func.pyname }}'] = {
+{%- for key, value in stat.doc_info.statuscodes.items() %}
+    {{ '{!r}'.format(key) }}: {{ '{!r}'.format(value) }},
+{%- endfor %}
+}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{# done! (note: this comment also ensures final new line!) #}

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -53,13 +53,19 @@ def test_erfa_wrapper():
     ra = np.linspace(0.0, np.pi*2.0, 5)
     dec = np.linspace(-np.pi/2.0, np.pi/2.0, 4)
 
-    aob, zob, hob, dob, rob, eo = erfa.atco13(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd, 0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
+    aob, zob, hob, dob, rob, eo = erfa.atco13(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd,
+        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
     assert aob.shape == (121,)
 
-    aob, zob, hob, dob, rob, eo = erfa.atco13(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd[0], 0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
+    aob, zob, hob, dob, rob, eo = erfa.atco13(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd[0],
+        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
     assert aob.shape == ()
 
-    aob, zob, hob, dob, rob, eo = erfa.atco13(ra[:, None, None], dec[None, :, None], 0.0, 0.0, 0.0, 0.0, jd[None, None, :], 0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
+    aob, zob, hob, dob, rob, eo = erfa.atco13(
+        ra[:, None, None], dec[None, :, None], 0.0, 0.0, 0.0, 0.0, jd[None, None, :],
+        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
     (aob.shape) == (5, 4, 121)
 
     iy, im, id, ihmsf = erfa.d2dtf("UTC", 3, jd, 0.0)
@@ -167,7 +173,8 @@ def test_errwarn_reporting():
         erfa.dat(200, [1, 34, 2], [1, 1, 43], 0.5)
     except erfa.ErfaError as e:
         if 'warning' in e.args[0]:
-            assert False, 'Raised the correct type of error, but there were warnings mixed in: ' + e.args[0]
+            assert False, ('Raised the correct type of error, but there were '
+                           'warnings mixed in: ' + e.args[0])
 
 
 def test_vector_inouts():

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -29,7 +29,7 @@
     "Returns\n" \
     "-------\n" \
     "leap_seconds : `~numpy.ndarray`\n" \
-    "    With structured dtype `~astropy._erfa.dt_eraLEAPSECOND`,\n" \
+    "    With structured dtype `~erfa.dt_eraLEAPSECOND`,\n" \
     "    containing items 'year', 'month', and 'tai_utc'."
 #define SET_LEAP_SECONDS_DOCSTRING \
     "set_leap_seconds([table])\n\n" \
@@ -37,7 +37,7 @@
     "Parameters\n" \
     "----------\n" \
     "leap_seconds : array_like, optional\n" \
-    "    With structured dtype `~astropy._erfa.dt_eraLEAPSECOND`,\n" \
+    "    With structured dtype `~erfa.dt_eraLEAPSECOND`,\n" \
     "    containing items 'year', 'month', and 'tai_utc'.\n" \
     "    If not given, reset to the ERFA built-in table.\n\n" \
     "Notes\n" \
@@ -751,7 +751,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
      * Make the version information available in the module.
      * Note that this gets run every time _erfa is imported,
      * hence if the library is provided by the system rather
-     * than bundled with astropy, one correctly gets the version
+     * than bundled with pyerfa, one correctly gets the version
      * information from the system library.
      */
     erfa_version = PyUnicode_FromString(eraVersion());

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -114,6 +114,24 @@ class FunctionDoc:
 
         return self.__ret_info
 
+    @property
+    def title(self):
+        # Used for the docstring title.
+        lines = [line.strip() for line in self.doc.split('\n')[4:10]]
+        # Always include the first line, then stop at either an empty
+        # line or at the end of a sentence.
+        description = lines[:1]
+        for line in lines[1:]:
+            if line == '':
+                break
+            if '. ' in line:
+                line = line[:line.index('. ')+1]
+            description.append(line)
+            if line.endswith('.'):
+                break
+
+        return '\n    '.join(description)
+
     def __repr__(self):
         return self.doc.replace("  \n", "\n")
 


### PR DESCRIPTION
The discussion in https://github.com/liberfa/erfa/issues/24 made me realize that the current docstrings for the python functions are less than helpful, having as title just "Wrapper for ...", which tells one very little. So, I changed the generator such that it uses the first sentence of the description instead.  The summary in particular is more descriptive (see below).

As I was a bit irritated in seeing red wiggles while editing various files, I also made everything PEP8 compliant (with slightly longer lines). Finally, in the C code a few mentions of astropy were still present, so I took the opportunity to change those. Those may make review a bit more messy; it may make most sense to look by commit...

![image](https://user-images.githubusercontent.com/2789820/90081007-33e75000-dcda-11ea-8fa6-82b640b55415.png)
