### PR TITLE
Return ErfaWarning msg to old format

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -121,7 +121,7 @@ def check_errwarn(statcodes, func_name):
 
         wmsg = ', '.join(['{0} of "{1}"'.format(warncounts[w], warnmsgs[w])
                           for w in warncodes])
-        warnings.warn('ERFA function {!r} yielded {}'.format(func_name, wmsg),
+        warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
                       ErfaWarning)
 
 


### PR DESCRIPTION
A single commit to change the ErfaWarning msg format back to what it used to be.

Fixes #48 