### PR TITLE
Ensure warning message is same as before.

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -100,7 +100,8 @@ def check_errwarn(statcodes, func_name):
 
         emsg = ', '.join(['{0} of "{1}"'.format(errcounts[e], errmsgs[e])
                           for e in errcodes])
-        raise ErfaError('ERFA function "' + func_name + '" yielded ' + emsg)
+        raise ErfaError('ERFA function "{}" yielded {}'
+                        .format(func_name, emsg))
 
     elif numpy.any(statcodes > 0):
         # Only warnings present.
@@ -121,7 +122,7 @@ def check_errwarn(statcodes, func_name):
 
         wmsg = ', '.join(['{0} of "{1}"'.format(warncounts[w], warnmsgs[w])
                           for w in warncodes])
-        warnings.warn('ERFA function {!r} yielded {}'.format(func_name, wmsg),
+        warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
                       ErfaWarning)
 
 


### PR DESCRIPTION
It turns out #47 caused astropy failures, because the messages in warnings had subtly changed. This PR ensures the message are as they were before (whether one should really test that precisely is another question, but really no need to give people work!).

p.s. I'll just merge this if tests pass since it is quite trivial.