### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,12 +18,6 @@ jobs:
 
         include:
 
-          # - name: Tests that all the basics are covered
-          #   os: ubuntu-latest
-          #   python: 3.8
-          #   toxenv: test
-          #   toxargs: -v
-
           - name: Test with oldest supported versions of our dependencies
             os: ubuntu-16.04
             python: 3.6

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: ${{ matrix.name }} [ ${{ matrix.os }} ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: [3.8]
+        toxenv: [test]
+        toxargs: [-v]
+
+        include:
+
+          # - name: Tests that all the basics are covered
+          #   os: ubuntu-latest
+          #   python: 3.8
+          #   toxenv: test
+          #   toxargs: -v
+
+          - name: Test with oldest supported versions of our dependencies
+            os: ubuntu-16.04
+            python: 3.6
+            toxenv: test-oldestdeps
+            toxargs: -v
+
+          - name: Test with development versions of our dependencies
+            os: ubuntu-20.04  # currently newer than ubuntu-latest
+            python: 3.9
+            toxenv: test-devdeps
+            toxargs: -v
+
+          - name: Code style checks
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: codestyle
+            toxargs: -v
+
+          - name: Documentation build
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: build_docs
+            toxargs: -v
+            apt_packages: graphviz
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install APT packages
+      if: matrix.apt_packages
+      run: sudo apt-get install ${{ matrix.apt_packages }}
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox
+    - name: Run tests
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+
+  tests_external_liberfa:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    env:
+      PYERFA_USE_SYSTEM_LIBERFA: 1
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+
+          - name: Tests with external liberfa
+            os: ubuntu-20.04
+            python: 3.8
+            toxenv: test
+            toxargs: -v
+            apt_packages: python3-venv python3-pip liberfa-dev python3-numpy
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install APT packages
+      if: matrix.apt_packages
+      run: sudo apt-get install ${{ matrix.apt_packages }}
+    - name: Run tests
+      run: |
+        python -m venv --system-site-packages tests
+        source tests/bin/activate
+        python -m pip install --editable .[test]
+        (nm -u erfa/ufunc.cpython-*.so | grep eraA2af) || exit 1
+        python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,27 +38,6 @@ env:
 
 jobs:
     include:
-        - name: Tests that all the basics are covered.
-          stage: Initial tests
-          env: TOXENV=test
-
-        - name: Documentation build
-          stage: Comprehensive tests
-          env: TOXENV=build_docs
-          addons:
-              apt:
-                  packages:
-                      - graphviz
-
-        - name: Test with oldest supported versions of our dependencies
-          stage: Comprehensive tests
-          python: 3.6
-          env: TOXENV=test-oldestdeps
-
-        - name: Test with development versions of our dependencies
-          stage: Comprehensive tests
-          python: 3.9-dev
-          env: TOXENV=test-devdeps
 
         # We try our apt test on the big-endian s390x architecture,
         # to check that things work there as well. We also test that

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ def get_extensions():
     define_macros = []
 
     if int(os.environ.get('PYERFA_USE_SYSTEM_LIBERFA', 0)):
+        print('Using system liberfa')
         libraries.append('erfa')
     else:
         # get all of the .c files in the liberfa/erfa/src directory


### PR DESCRIPTION
With this PR most of the CI jobs previously run on Travis-CI are now moved to GitHub Actions.
The only job still remaining active on Travis is the one on s390x: the architecture seem to be not available in GitHub Actions AFAIK.

The setup of GitHub Actions is based on the one of astropy and replicates quite closely the jobs previously performed on Travis-CI. 

Jobs for Mac OS X and Windows has been added (this PR basically superseded PR #55).


Edit:
GitHub actions seems to be not triggered on PRs. You can give a look to results [here](https://github.com/avalentino/pyerfa/actions/runs/363098156)