### PR TITLE
The classproperty decorator is now thread-safe (closes #63)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.7.x.y (UNRELEASED)
+====================
+
+- The classproperty decorator is now thread-safe
+  (backport https://github.com/astropy/astropy/pull/11224).
+
+
 1.7.1.1 (18/11/2020)
 ====================
 


### PR DESCRIPTION
Backport https://github.com/astropy/astropy/pull/11224

Closes #63.

Please note that we do not have tests for functions in ``erfa.helpers``.
Do we need them?
Actually only ``leap_seconds`` is part of the API.