### PR TITLE
Ensure that inout arguments are properly accounted for twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
+1.7.3 (unreleased)
+==================
+
+- Fixed a bug that caused the output of ``rx``, ``ry``, and ``rz`` to be
+  boolean rather than float. [gh-72]
+
 1.7.2 (25/01/2021)
-====================
+==================
 
 - Bundled liberfa version update to v1.7.2.
 - The classproperty decorator is now thread-safe

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 import erfa
 from erfa.tests.helper import catch_warnings
@@ -233,6 +233,15 @@ def test_vector_inouts():
     res3 = erfa.ab(arrin[::5], v, s, bm1)
     assert res3.shape == (4, 3)
     np.testing.assert_allclose(res3, [expected]*4)
+
+
+def test_rz():
+    # This failed on MacOS (gh-68) because the types were not set correctly.
+    r = erfa.rz(np.deg2rad(60.), np.eye(3))
+    assert_array_almost_equal(r, np.array(
+        [[0.5, 0.8660254, 0.],
+         [-0.8660254, 0.5, 0.],
+         [0., 0., 1.]]))
 
 
 def test_pv_in():

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -734,7 +734,12 @@ PyMODINIT_FUNC PyInit_ufunc(void)
            as these do not get copied */ #}
     {%- for func in funcs %}
     {%- if not func.user_dtype %}
-    static char types_{{ func.pyname }}[{{ func.args_by_inout('in|inout|out|ret|stat')|count }}] = { {{ func.args_by_inout('in|inout|out|ret|stat')|map(attribute='npy_type')|join(', ') }} };
+    static char types_{{ func.pyname }}[{{ func.args_by_inout('in|inout')|count
+                                         + func.args_by_inout('inout|out|ret|stat')|count }}] = {
+    {%- for arg in func.args_by_inout('in|inout') %}{{ arg.npy_type }}, {% endfor %}
+    {%- for arg in func.args_by_inout('inout|out|ret|stat') -%}
+    {%- if loop.index > 1 %}, {% endif %}{{ arg.npy_type }}{%- endfor -%}
+    };
     static PyUFuncGenericFunction funcs_{{ func.pyname }}[1] = { &ufunc_loop_{{ func.pyname }} };
     {%- endif %}
     {%- endfor %}


### PR DESCRIPTION
This is in setting the types for regular ufuncs.

Fixes #68