### PR TITLE
Update to erfa 1.7.3

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -56,6 +56,9 @@ jobs:
     - name: Install APT packages
       if: matrix.apt_packages
       run: sudo apt-get install ${{ matrix.apt_packages }}
+    - name: Install packages for macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install autoconf automake
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox
     - name: Run tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
-1.7.3 (unreleased)
+1.7.3 (25/04/2021)
 ==================
 
+- Bundled liberfa version update to v1.7.3.
 - Fixed a bug that caused the output of ``rx``, ``ry``, and ``rz`` to be
-  boolean rather than float. [gh-72]
+  boolean rather than float for some compilers/OS. [gh-72]
 
 1.7.2 (25/01/2021)
 ==================

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -17,6 +17,18 @@ environment::
     git clean -fxd
     tox -e test
 
+It is also wise to check that the new release works with astropy::
+
+    python3 -m venv astropy_test
+    source astropy_test/bin/activate
+    pip install astropy[test]
+    pip install .  # Install our newest erfa version in virtual environment
+    cd astropy_test/lib/python3.9/site-packages/astropy
+    pytest --remote-data=any
+    cd -
+    deactivate
+    git clean -fxd
+
 Once the package is ready to release, first edit ``CHANGES.rst`` to
 add the release data (and add any information needed, such as an
 update to the bundled ``liberfa``).

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -49,7 +49,8 @@ class TestVersion:
         assert hasattr(erfa.version, 'sofa_version')
         sofa_version = erfa.version.sofa_version
         assert isinstance(sofa_version, str)
-        assert len(sofa_version) == 8
+        assert (len(sofa_version) == 8
+                or len(sofa_version) == 10 and sofa_version[8] == '_')
         # Sorry, future 22nd century person, you may have to adjust!
         assert sofa_version.startswith('20')
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_liberfa_versions(path=os.path.join(LIBERFADIR, 'configure.ac')):
     version = packaging.version.parse(mobj.group('version'))
 
     mobj = re.search(
-        r'AC_DEFINE\(\[SOFA_VERSION\], \["(?P<version>\d{8})"\],', s)
+        r'AC_DEFINE\(\[SOFA_VERSION\], \["(?P<version>\d{8}(_\w)?)"\],', s)
     if not mobj:
         warn('unable to detect SOFA version')
         return []


### PR DESCRIPTION
Hmm, I tried pushing this directly to master to release 1.7.3, but it failed on windows and macos, so I presume it will fail here too.

I sort-of feel I have seen this before, and it seems the erfa release is missing the `configure` file. If so, we may need a new release there that includes it (or can we include after the fact?). @astrofrog, @avalentino - advice much appreciated!

We certainly need to update the relevant release instructions...