### PR TITLE
Correct dtype for ldbody

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,14 @@
-1.7.4 (unreleased)
-==================
+1.7.3.1 (unreleased)
+====================
 
+- ``erfa.dt_eraLDBODY`` has been corrected to ensure that the 'pv' entry is
+  now of type ``erfa.dt_pv``, so that cross-assignments with that dtype work
+  correctly. [gh-74]
 - ``erfa_generator`` now also generates a ``test_ufunc.py`` file that
   runs all the C code tests on the ufuncs, thus verifying the code
   wrapping worked correctly. As part of that, the ability to give
   specific output file names has been removed, as it was not used.
-  (Note: these changes have no effect on use of PyERFA.)
+  (Note: these changes have no effect on use of PyERFA.) [gh-71]
 
 1.7.3 (25/04/2021)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ as `numpy.dtype` corresponding to structures used by ERFA_.  Examples::
   >>> erfa.dt_pv
   dtype([('p', '<f8', (3,)), ('v', '<f8', (3,))], align=True)
   >>> erfa.dt_eraLDBODY
-  dtype([('bm', '<f8'), ('dl', '<f8'), ('pv', '<f8', (2, 3))], align=True)
+  dtype([('bm', '<f8'), ('dl', '<f8'), ('pv', [('p', '<f8', (3,)), ('v', '<f8', (3,))])], align=True)
   >>> erfa.DAYSEC
   86400.0
 

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -808,15 +808,6 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     dtype_def = Py_BuildValue("[(s, s)]", "type", "S12");
     PyArray_DescrAlignConverter(dtype_def, &dt_type);
     Py_DECREF(dtype_def);
-    /* eraLDBODY */
-    dtype_def = Py_BuildValue(
-        "[(s, s), (s, s), (s, s)]",
-        "bm", "f8",     /* mass of the body (solar masses) */
-        "dl", "f8",     /* deflection limiter (radians^2/2) */
-        "pv", "(2,3)f8" /* barycentric PV of the body (au, au/day) */
-        );
-    PyArray_DescrAlignConverter(dtype_def, &dt_eraLDBODY);
-    Py_DECREF(dtype_def);
     /* eraASTROM */
     dtype_def = Py_BuildValue(
         "[(s, s), (s, s), (s, s), (s, s),"
@@ -853,8 +844,19 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         dt_pv == NULL || dt_pvdpv == NULL ||
         dt_ymdf == NULL || dt_hmsf == NULL || dt_dmsf == NULL ||
         dt_sign == NULL || dt_type == NULL ||
-        dt_eraLDBODY == NULL || dt_eraASTROM == NULL ||
-        dt_eraLEAPSECOND == NULL) {
+        dt_eraASTROM == NULL || dt_eraLEAPSECOND == NULL) {
+        goto fail;
+    }
+    /* eraLDBODY (needs dt_pv, so after check that that is OK) */
+    dtype_def = Py_BuildValue(
+        "[(s, s), (s, s), (s, O)]",
+        "bm", "f8",     /* mass of the body (solar masses) */
+        "dl", "f8",     /* deflection limiter (radians^2/2) */
+        "pv", dt_pv     /* barycentric PV of the body (au, au/day) */
+        );
+    PyArray_DescrAlignConverter(dtype_def, &dt_eraLDBODY);
+    Py_DECREF(dtype_def);
+    if (dt_eraLDBODY == NULL) {
         goto fail;
     }
     /* Make the structured dtypes available in the module */

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -703,6 +703,8 @@ class TestFunction:
                     .replace('ERFA_', 'erfa.')
                     .replace('(void)', '')
                     .replace('(int)', '')
+                    .replace("pv[0]", "pv['p']")
+                    .replace("pv[1]", "pv['v']")
                     .replace("s, '-'", "s[0], b'-'")  # Rather hacky...
                     .replace("s, '+'", "s[0], b'+'")  # Rather hacky...
                     .strip())
@@ -775,10 +777,12 @@ class TestFunction:
                 # Hack to make astrom element assignment work.
                 if line.startswith('astrom'):
                     out.append('astrom = np.zeros((), erfa_ufunc.dt_eraASTROM).view(np.recarray)')
-                # Change access to p and v elements for double[2][3] pv arrays.
+                # Change access to p and v elements for double[2][3] pv arrays
+                # that were not caught by the general replacement above (e.g.,
+                # with names not equal to 'pv')
                 name, _, rest = line.partition('[')
-                if rest and name in self.var_dtypes and self.var_dtypes[name] == 'dt_pv':
-                    assert rest[0] in '01'
+                if (rest and rest[0] in '01' and name in self.var_dtypes
+                        and self.var_dtypes[name] == 'dt_pv'):
                     line = name + "[" + ("'p'" if rest[0] == "0" else "'v'") + rest[1:]
 
             out.append(line)


### PR DESCRIPTION
I've been writing a `StructuredUnit`/`StructuredQuantity` PR for astropy that allows all erfa functions to be used with quantity, and found that the dtype for `LDBODY` is actually wrong, in that it combined position and velocity in one array (which thus cannot have different units), while it should have used the `dt_pv` dtype. This corrects that.

As I was surprised the new complete tests didn't catch that, I also looked into that: turned out to be a bit of an accidental pass. That one is now corrected too.

p.s. May make a quick bugfix release for that if I get my structured quantity PR wrapped up.