### PR TITLE
Update to erfa 2.0.0

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -100,4 +100,4 @@ jobs:
         source tests/bin/activate
         python -m pip install --editable .[test]
         (nm -u erfa/ufunc.cpython-*.so | grep eraA2af) || exit 1
-        python -m pytest
+        (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || python -m pytest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -20,7 +20,7 @@ jobs:
 
           - name: Test with oldest supported versions of our dependencies
             os: ubuntu-16.04
-            python: 3.6
+            python: 3.7
             toxenv: test-oldestdeps
             toxargs: -v
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 # Other generated files
 MANIFEST
 erfa/core.py
+erfa/tests/test_ufunc.py
 erfa/_version.py
 
 # Sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,5 @@ script:
         source tests/bin/activate;
         pip3 install --no-deps --editable .[test];
         (nm -u erfa/ufunc.cpython-*.so | grep eraA2af) || exit 1;
-        pytest-3;
+        (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || pytest-3;
       fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
-1.7.3.1 (unreleased)
-====================
+2.0.0 (unreleased)
+==================
 
+- Bundled liberfa version update to v2.0.0. This includes new functionality,
+  and hence pyerfa 2.0.0 cannot run with previous versions of liberfa.
 - ``erfa.dt_eraLDBODY`` has been corrected to ensure that the 'pv' entry is
   now of type ``erfa.dt_pv``, so that cross-assignments with that dtype work
   correctly. [gh-74]

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -17,15 +17,15 @@ environment::
     git clean -fxd
     tox -e test
 
-It is also wise to check that the new release works with astropy::
+It is also wise to check that the new release works with astropy.
+We can use the ``tox`` environment we just created, but have to be sure
+to leave the package directory::
 
-    python3 -m venv astropy_test
-    source astropy_test/bin/activate
+    source .tox/test/bin/activate
+    cd ~  #
     pip install astropy[test]
-    pip install .  # Install our newest erfa version in virtual environment
-    cd astropy_test/lib/python3.9/site-packages/astropy
-    pytest --remote-data=any
-    cd -
+    pytest --pyargs astropy --remote-data=any
+    cd -  # Back to the package directory.
     deactivate
     git clean -fxd
 

--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+# Import version first, as this gives a more useful error message
+# if a system liberfa is too old.
+from .version import version as __version__  # noqa
 from .core import *  # noqa
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND,  # noqa
                     dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
 from .helpers import leap_seconds  # noqa
-from .version import version as __version__  # noqa

--- a/erfa/version.py
+++ b/erfa/version.py
@@ -21,7 +21,30 @@ except Exception:
 
 # Set the version numbers a bit indirectly, so that Sphinx can pick up
 # up the docstrings and list the values.
-from . import ufunc
+try:
+    from . import ufunc
+except ImportError as exc:
+    # If compiled to use a system liberfa, that library can be too old, and
+    # miss functions that are available in newer liberfa. If so, we should
+    # bail since nothing will work, but let's try to give a more informative
+    # error message.
+    try:
+        from ctypes import CDLL, util, c_char_p
+        liberfa = CDLL(util.find_library('erfa'))
+        liberfa.eraVersion.restype = c_char_p
+        erfa_version = liberfa.eraVersion().decode('ascii')
+    except Exception:
+        pass
+    else:
+        if erfa_version.split(".")[:2] < _version.split(".")[:2]:
+            raise ImportError(
+                f"liberfa {erfa_version} too old for PyERFA {_version}. "
+                "This should only be possible if you are using a system liberfa; "
+                "try installing using 'pip install pyerfa', with environment variable "
+                "PYERFA_USE_SYSTEM_LIBERFA unset or 0.") from exc
+
+    raise
+
 
 version = _version
 '''Version of the python wrappers.'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ requires = numpy
 zip_safe = False
 tests_require = pytest-doctestplus
 setup_requires = setuptools_scm
-install_requires = numpy>=1.16
-python_requires = >=3.6
+install_requires = numpy>=1.17
+python_requires = >=3.7
 
 [options.packages.find]
 exclude = erfa._dev

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ extras =
 
 commands =
     pip freeze
+    python -c 'import erfa'  # To give useful error message if liberfa is too old.
     pytest --pyargs erfa {toxinidir}/docs {posargs}
 
 [testenv:build_docs]


### PR DESCRIPTION
This is a backward incompatible change in liberfa, which meant that locally at least the test with system liberfa broke (since it is obviously too old, me just having released liberfa 2.0.0). 

I found it very annoying that with a system library, the import just crashes without a useful error message. To help remedy that, I split out the version information form the ufuncs - this new module should always work. It has the advantage that the ufunc library only relies on stuff copied from SOFA (well, with the leap second addition to `dat.c`), not on extra routines we introduced.

But am not 100% sure my approach is the best; suggestions welcome!

p.s. I include some updates the the release instructions, since following them to test with astropy did not work...