### PR TITLE
Allow structured output of the right type.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.0.0.1 (unreleased)
+====================
+
+- The underlying universal functions in ``erfa.ufunc`` now work with an ``out``
+  argument also if the required output is a structured array. [gh-76]
+
 2.0.0 (17/05/2021)
 ==================
 

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -286,6 +286,24 @@ def test_pv_in():
     np.testing.assert_allclose(astrom3['em'], 1.010428384373318379)
 
 
+def test_pv_out():
+    """Test that ufunc can also deal with 'out' argument."""
+    pv = erfa.ufunc.s2pv(np.pi/2.0, np.pi/4.0, 2.0, np.sqrt(2.0)/2.0, 0.0, 0.0)
+    pv2 = np.empty_like(pv)
+    out = erfa.ufunc.s2pv(np.pi/2.0, np.pi/4.0, 2.0, np.sqrt(2.0)/2.0, 0.0, 0.0,
+                          out=pv2)
+    assert out is pv2
+    assert np.all(pv2 == pv)
+
+
+def test_zpv_out():
+    """Test that no-input routines work with 'out' argument."""
+    pv = np.zeros(10, erfa.dt_pv)
+    out = erfa.ufunc.zpv(out=pv)
+    assert out is pv
+    np.testing.assert_array_equal(pv, np.zeros(10, erfa.dt_pv))
+
+
 def test_struct_ldbody():
     """
     Check dt_eraLDBODY is correctly defined (regression test; gh-74)

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -402,21 +402,32 @@ ufunc_loop_matches(PyUFuncObject *self,
     }
     /*
      * All inputs were ok; now check casting back to the outputs.
-     * MHvK: Since no casting from structured to non-structured is
-     * possible, no changes needed here.
+     * For void, only allow casting to the same void.
      */
     for (i = nin; i < nop; ++i) {
         if (op[i] != NULL) {
-            PyArray_Descr *tmp = PyArray_DescrFromType(types[i]);
-            if (tmp == NULL) {
-                return -1;
+            if (types[i] == NPY_VOID && dtypes != NULL) {
+                PyArray_Descr *op_descr = PyArray_DESCR(op[i]);
+                /*
+                 * MHvK: for VOID, we only allow VOID->same VOID.
+                 */
+                if (op_descr->type_num != NPY_VOID
+                    || !PyArray_EquivTypes(op_descr, dtypes[i])) {
+                    return 0;
+                }
             }
-            if (!PyArray_CanCastTypeTo(tmp, PyArray_DESCR(op[i]),
+            else {
+                PyArray_Descr *tmp = PyArray_DescrFromType(types[i]);
+                if (tmp == NULL) {
+                    return -1;
+                }
+                if (!PyArray_CanCastTypeTo(tmp, PyArray_DESCR(op[i]),
                                        casting)) {
+                    Py_DECREF(tmp);
+                    return 0;
+                }
                 Py_DECREF(tmp);
-                return 0;
             }
-            Py_DECREF(tmp);
         }
     }
     return 1;


### PR DESCRIPTION
Previously, this was not allowed as it did only a general check on VOID->VOID casting, which is not allowed.

fixes #70