### PR TITLE
Adding git and PyPI references to Installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,11 @@ and similarly a wheel_ can be created with::
 
 .. _wheel: https://github.com/pypa/wheel
 
+The package can be obtained from PyPI_ or directly from the git repository::
+
+  $ git clone --recursive https://github.com/liberfa/pyerfa/
+
+
 
 Testing
 -------
@@ -108,6 +113,7 @@ PyERFA is licensed under a 3-clause BSD style license - see the
 .. _ERFA: https://github.com/liberfa/erfa
 .. _Numpy: https://numpy.org/
 .. _Astropy: https://www.astropy.org
+.. _PyPI: https://pypi.org/project/pyerfa/
 .. _Jinja2: https://palletsprojects.com/p/jinja/
 .. |PyPI Status| image:: https://img.shields.io/pypi/v/pyerfa.svg
     :target: https://pypi.python.org/pypi/pyerfa


### PR DESCRIPTION
Solves issue #80 (trouble cloning git repo) by adding instructions to use `git clone --recursive`