### PR TITLE
Update the OS version for the "oldest" CI run.

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -19,7 +19,7 @@ jobs:
         include:
 
           - name: Test with oldest supported versions of our dependencies
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             python: 3.7
             toxenv: test-oldestdeps
             toxargs: -v


### PR DESCRIPTION
The "ubuntu-16.04" image seems to be no longer available on GHA (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).
Use "ubuntu-18.04" instead.