### PR TITLE
Ensure we use only public methods of setuptools-scm Version class.

### DIFF
--- a/erfa/_dev/scm_version.py
+++ b/erfa/_dev/scm_version.py
@@ -33,7 +33,7 @@ try:
             if erfa_tag > version_string:
                 guessed = erfa_tag
             elif 'dev' in version_string or len(version_string.split('.')) > 3:
-                return guess_next_version(version.tag)
+                return version.format_next_version(guess_next_version)
             else:
                 guessed = version_string.partition("+")[0] + '.1'
             return version.format_with("{guessed}.dev{distance}",

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -145,12 +145,14 @@ dt_bytes12 = numpy.dtype('S12')
 def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }}):
     """
     {{ func.doc.title }}
+    {%- if func.args_by_inout('in|inout') %}
 
     Parameters
     ----------
     {%- for arg in func.args_by_inout('in|inout') %}
     {{ arg.name }} : {{ arg.ctype }} array
     {%- endfor %}
+    {%- endif %}
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel",
+requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel",
             "packaging", "jinja2>=2.10.3", "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
As it was, we used version.guess_next_version, which in setuptools-scm
version 7 takes a different argument.  Also set the minimum version
to be the same as used for astropy.

fixes #84