### PR TITLE
Make use of CPython limited API

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -113,7 +113,7 @@ jobs:
         python -m venv --system-site-packages tests
         source tests/bin/activate
         python -m pip install --editable .[test]
-        (nm -u erfa/ufunc.cpython-*.so | grep eraA2af) || exit 1
+        (nm -u erfa/ufunc.*.so | grep eraA2af) || exit 1
         (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || python -m pytest
 
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -126,37 +126,16 @@ jobs:
       test_command: pytest --pyargs erfa
       targets: |
         # Linux wheels
-        - cp39-manylinux_x86_64
-        - cp310-manylinux_x86_64
-        - cp311-manylinux_x86_64
-        - cp312-manylinux_x86_64
-        - cp39-musllinux_x86_64
-        - cp310-musllinux_x86_64
-        - cp311-musllinux_x86_64
-        - cp312-musllinux_x86_64
-        - cp39-manylinux_aarch64
-        - cp310-manylinux_aarch64
-        - cp311-manylinux_aarch64
-        - cp312-manylinux_aarch64
+        - cp3*-manylinux_x86_64
+        - cp3*-musllinux_x86_64
+        - cp3*-manylinux_aarch64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
-        - cp39*macosx_x86_64
-        - cp310*macosx_x86_64
-        - cp311*macosx_x86_64
-        - cp312*macosx_x86_64
-        - cp39*macosx_arm64
-        - cp310*macosx_arm64
-        - cp311*macosx_arm64
-        - cp312*macosx_arm64
+        - cp3*macosx_x86_64
+        - cp3*macosx_arm64
         # Windows wheels
-        - cp39*win32
-        - cp310*win32
-        - cp311*win32
-        - cp312*win32
-        - cp39*win_amd64
-        - cp310*win_amd64
-        - cp311*win_amd64
-        - cp312*win_amd64
+        - cp3*win32
+        - cp3*win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -17,6 +17,13 @@
 #include "erfa.h"
 #include "erfaextra.h"
 
+// On gcc<10 we can run into the following:
+//
+//   error: dereferencing pointer to incomplete type 'PyTypeObject'
+//
+// As mentioned in https://github.com/numpy/numpy/issues/16970,
+// the workaround is to define a fake _typeobject struct.
+
 struct _typeobject {
     int dummy;
 };

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -10,7 +10,7 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define Py_LIMITED_API 0x030700f0
+#define Py_LIMITED_API 0x030900f0
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -17,6 +17,8 @@
 #include "erfa.h"
 #include "erfaextra.h"
 
+struct _typeobject {};
+
 #define MODULE_DOCSTRING \
     "Ufunc wrappers of the ERFA routines.\n\n" \
     "These ufuncs vectorize the ERFA functions assuming structured dtypes\n" \

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -210,7 +210,7 @@ static void ufunc_loop_{{ func.pyname }}(
    {#- /* if needed, allocate memory for contiguous eraLDBODY copies */ #}
    {%- if func.user_dtype == 'dt_eraLDBODY' %}
     if (copy_b) {
-        _b = PyArray_malloc(nb * sizeof(eraLDBODY));
+        _b = malloc(nb * sizeof(eraLDBODY));
         if (_b == NULL) {
             PyErr_NoMemory();
             return;

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -17,7 +17,9 @@
 #include "erfa.h"
 #include "erfaextra.h"
 
-struct _typeobject {};
+struct _typeobject {
+    int dummy;
+};
 
 #define MODULE_DOCSTRING \
     "Ufunc wrappers of the ERFA routines.\n\n" \

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -219,6 +219,8 @@ static void ufunc_loop_{{ func.pyname }}(
    {#- /* if needed, allocate memory for contiguous eraLDBODY copies */ #}
    {%- if func.user_dtype == 'dt_eraLDBODY' %}
     if (copy_b) {
+        // Note that we can't use PyArray_malloc here as it is an alias to PyMem_RawMalloc
+        // which is not available in the Python limited API
         _b = malloc(nb * sizeof(eraLDBODY));
         if (_b == NULL) {
             PyErr_NoMemory();

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -10,6 +10,7 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define Py_LIMITED_API 0x030700f0
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,4 +58,4 @@ max-line-length = 100
 max-line-length = 100
 
 [bdist_wheel]
-py_limited_api = cp37
+py_limited_api = cp39

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,6 @@ max-line-length = 100
 
 [pycodestyle]
 max-line-length = 100
+
+[bdist_wheel]
+py_limited_api = cp37

--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,7 @@ def get_extensions():
         include_dirs=include_dirs,
         libraries=libraries,
         define_macros=define_macros,
+        py_limited_api=True,
         language="c")
 
     return [erfa_ext]


### PR DESCRIPTION
This is meant to be an experiment in trying to see if we can use the [Limited API](https://docs.python.org/3.10/c-api/stable.html) - doing so would mean we would only need to build one wheel for each platform (rather than one per Python version and per platform). Note that this wouldn't require any changes to the wheel building machinery as cibuildwheel recognizes this and will only build one wheel and test it on all Python versions.

I am running into the issue that ``PyArray_malloc`` is an alias of ``PyMem_RawMalloc`` which isn't in the Limited API. I was wondering if there is a way we can allocate the arrays that would be compatible with the Limited API, for example using ``PyMem_malloc`` or ``malloc``?

@mhvk - as a Numpy expert, do you have any ideas?