### PR TITLE
Revert mininum numpy change

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -24,6 +24,14 @@ jobs:
             toxenv: test-oldestdeps
             toxargs: -v
 
+          - name: Test with medium old supported versions of our dependencies
+            # Test that we do not have a problem with some specific version (gh-101).
+            # Comment out if not needed.
+            os: ubuntu-20.04
+            python: 3.9
+            toxenv: test-olddeps
+            toxargs: -v
+
           - name: Test with development versions of our dependencies
             os: ubuntu-latest
             python: 3.11

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.0.0.3 (2023-03-22)
+====================
+
+- Ensure minimum numpy version of 1.17 continues to work (for astropy LTS).
+
 2.0.0.2 (2023-03-19)
 ====================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ requires = numpy
 zip_safe = False
 tests_require = pytest-doctestplus
 setup_requires = setuptools_scm
-install_requires = numpy>=1.21
+install_requires = numpy>=1.17
 python_requires = >=3.7
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    oldestdeps: numpy==1.21.*
+    oldestdeps: numpy==1.17.*
     devdeps: numpy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    test{,-oldestdeps,-devdeps}
+    test{,-oldestdeps,-olddeps,-devdeps}
     build_docs
     linkcheck
     codestyle
@@ -32,11 +32,13 @@ changedir = .tmp/{envname}
 description =
     run tests
     devdeps: with the latest developer version of key dependencies
+    olddeps: with medium old versions of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
 
 # The following provides some specific pinnings for key packages
 deps =
-    oldestdeps: numpy==1.17.*
+    oldestdeps: numpy==1.17.*  # astropy LTS
+    olddeps: numpy==1.20.*  # something potentially problematic (see gh-101)
     devdeps: numpy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
This is to ensure astropy LTS does not have to pin. Added an extra test for numpy 1.20 since that was problematic before.