### PR TITLE
Generalize erfa_generator.py

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -686,8 +686,10 @@ class TestFunction:
             # (hack: only happens for double).
             if line.startswith('double') and '=' in line:
                 # Complete hack for single occurrence.
-                if line.startswith('double xyz[] = {'):
-                    out.append(f"xyz = np.array([{line[16:-1]}])")
+                if line.startswith('double xyz'):
+                    var_name = line.split(' ')[1].strip('[]')
+                    arr_index = line.rfind('{')+1
+                    out.append(f"{var_name} = np.array([{line[arr_index:-1]}])")
                 else:
                     # Put each definition on a separate line.
                     out.extend([part.strip() for part in line[7:].split(',')])


### PR DESCRIPTION
Dear maintainers,

this pull request is related to https://github.com/liberfa/erfa/pull/94.
Some modifications to the tests there make `erfa_generator.py` obsolete.
The changes suggested here are back compatible, hence if maintainers agree with them, they can be merged without waiting for https://github.com/liberfa/erfa/pull/94.

Thanks for considering it.

This work is funded by the Europlanet 2024 Research Infrastructure (RI) Grant.