### PR TITLE
Add Python 3.12 job and wheels

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -38,7 +38,7 @@ jobs:
 
           - name: Test with development versions of our dependencies
             os: ubuntu-latest
-            python: '3.11'
+            python: '3.12-dev'
             toxenv: test-devdeps
             toxargs: -v
 
@@ -127,27 +127,34 @@ jobs:
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
+        - cp312-manylinux_x86_64
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
         - cp311-musllinux_x86_64
+        - cp312-musllinux_x86_64
         - cp39-manylinux_aarch64
         - cp310-manylinux_aarch64
         - cp311-manylinux_aarch64
+        - cp312-manylinux_aarch64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
+        - cp312*macosx_x86_64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
+        - cp312*macosx_arm64
         # Windows wheels
         - cp39*win32
         - cp310*win32
         - cp311*win32
+        - cp312*win32
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
+        - cp312*win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -150,10 +150,6 @@ jobs:
         - cp311*macosx_arm64
         - cp312*macosx_arm64
         # Windows wheels
-        - cp39*win32
-        - cp310*win32
-        - cp311*win32
-        - cp312*win32
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -162,6 +162,6 @@ jobs:
       # Required so that cp312 can grab a pre-release numpy.
       # Can remove when cp312 is released.
       env: |
-        CIBW_ENVIRONMENT: 'PIP_PRE=$( if [ "${CIBW_BUILD:0:5}" = "cp312" ]; then echo 1; else echo 0; fi )'
+        CIBW_ENVIRONMENT: 'PIP_PRE=$( if [ "${CIBW_BUILD:0:5}" == "cp312" ]; then echo 1; else echo 0; fi )'
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -157,6 +157,6 @@ jobs:
       # Required so that cp312 can grab a pre-release numpy.
       # Can remove when cp312 is released.
       env: |
-        CIBW_ENVIRONMENT: PIP_PRE=1
+        CIBW_ENVIRONMENT: 'PIP_PRE=$( if [ "${CIBW_BUILD:0:5}" = "cp312" ]; then echo 1; else echo 0; fi )'
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -150,6 +150,11 @@ jobs:
         - cp311*macosx_arm64
         - cp312*macosx_arm64
         # Windows wheels
+        - cp39*win32
+        - cp310*win32
+        - cp311*win32
+        # TODO: Check again after cp312 and upstream are stable.
+        #- cp312*win32
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -158,5 +158,9 @@ jobs:
         - cp310*win_amd64
         - cp311*win_amd64
         - cp312*win_amd64
+      # Required so that cp312 can grab a pre-release numpy.
+      # Can remove when cp312 is released.
+      env: |
+        CIBW_ENVIRONMENT: PIP_PRE=1
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.9]
+        python: ['3.11']
         toxenv: [test]
         toxargs: [-v]
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -74,7 +74,9 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox
     - name: Run tests
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+      run: |
+        pip freeze
+        tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
 
   tests_external_liberfa:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -129,39 +129,57 @@ jobs:
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
-        - cp312-manylinux_x86_64
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
         - cp311-musllinux_x86_64
-        - cp312-musllinux_x86_64
         - cp39-manylinux_aarch64
         - cp310-manylinux_aarch64
         - cp311-manylinux_aarch64
-        - cp312-manylinux_aarch64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
-        - cp312*macosx_x86_64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
-        - cp312*macosx_arm64
         # Windows wheels
         - cp39*win32
         - cp310*win32
         - cp311*win32
-        # TODO: Check again after cp312 and upstream are stable.
-        #- cp312*win32
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
+
+  # TEMPORARY WORKAROUND: Have to separate this out to use unreleased NumPy for Python 3.12
+  # because shell command to conditionally set PIP_PRE is broken in OpenAstronomy/github-actions-workflows
+  # https://github.com/OpenAstronomy/github-actions-workflows/issues/152
+  build_and_publish_py312:
+
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    with:
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') }}
+      test_extras: test
+      test_command: pytest --pyargs erfa
+      targets: |
+        # Linux wheels
+        - cp312-manylinux_x86_64
+        - cp312-musllinux_x86_64
+        - cp312-manylinux_aarch64
+        # MacOS X wheels - we deliberately do not build universal2 wheels.
+        # Note that the arm64 wheels are not actually tested so we
+        # rely on local manual testing of these to make sure they are ok.
+        - cp312*macosx_x86_64
+        - cp312*macosx_arm64
+        # No NumPy wheel for win32
+        #- cp312*win32
         - cp312*win_amd64
       # Required so that cp312 can grab a pre-release numpy.
       # Can remove when cp312 is released.
       env: |
-        CIBW_ENVIRONMENT: 'PIP_PRE=$( if [ "${CIBW_BUILD:0:5}" == "cp312" ]; then echo 1; else echo 0; fi )'
+        CIBW_ENVIRONMENT: PIP_PRE=1
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ sphinx:
   fail_on_warning: false
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "setuptools_scm>=6.2",
     "jinja2>=2.10.3",
-    "numpy>=1.25,<2; python_version<'3.12'",
+    "numpy>=1.25,<2; python_version<='3.11'",
 
     # For Python versions which aren't yet officially supported, we specify an
     # unpinned NumPy which allows source distributions to be used and allows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,13 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml]>=6.2",
-            "packaging", "jinja2>=2.10.3", "numpy>=1.25,<2"]
+requires = [
+    "setuptools",
+    "setuptools_scm>=6.2",
+    "jinja2>=2.10.3",
+    "numpy>=1.25,<2; python_version<'3.12'",
+
+    # For Python versions which aren't yet officially supported, we specify an
+    # unpinned NumPy which allows source distributions to be used and allows
+    # wheels to be used as soon as they become available.
+    "numpy>=1.26.0b1; python_version>='3.12'"
+]
 build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "setuptools_scm>=6.2",
     "jinja2>=2.10.3",
-    "numpy>=1.25,<2; python_version<='3.11'",
+    "numpy>=1.25,<2; python_version<'3.12'",
 
     # For Python versions which aren't yet officially supported, we specify an
     # unpinned NumPy which allows source distributions to be used and allows


### PR DESCRIPTION
pyerfa won't build nicely in https://github.com/astropy/astropy/pull/14784 even after #107 and I don't know why.

Fix #108 maybe

Blocked by:

* https://github.com/OpenAstronomy/github-actions-workflows/issues/149

Questions:

- [x] Is it okay to use numpy 1.26b (pre-release) for all the wheels, not just cp312? Or do I have to separate out cp312 jobs?
- [x] Is it okay to drop win32 wheels?