### PR TITLE
Remove custom build requirements for Python 3.12

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -129,57 +129,34 @@ jobs:
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
+        - cp312-manylinux_x86_64
         - cp39-musllinux_x86_64
         - cp310-musllinux_x86_64
         - cp311-musllinux_x86_64
+        - cp312-musllinux_x86_64
         - cp39-manylinux_aarch64
         - cp310-manylinux_aarch64
         - cp311-manylinux_aarch64
+        - cp312-manylinux_aarch64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
+        - cp312*macosx_x86_64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
+        - cp312*macosx_arm64
         # Windows wheels
         - cp39*win32
         - cp310*win32
         - cp311*win32
+        - cp312*win32
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}
-
-  # TEMPORARY WORKAROUND: Have to separate this out to use unreleased NumPy for Python 3.12
-  # because shell command to conditionally set PIP_PRE is broken in OpenAstronomy/github-actions-workflows
-  # https://github.com/OpenAstronomy/github-actions-workflows/issues/152
-  build_and_publish_py312:
-
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
-    with:
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') }}
-      test_extras: test
-      test_command: pytest --pyargs erfa
-      targets: |
-        # Linux wheels
-        - cp312-manylinux_x86_64
-        - cp312-musllinux_x86_64
-        - cp312-manylinux_aarch64
-        # MacOS X wheels - we deliberately do not build universal2 wheels.
-        # Note that the arm64 wheels are not actually tested so we
-        # rely on local manual testing of these to make sure they are ok.
-        - cp312*macosx_x86_64
-        - cp312*macosx_arm64
-        # No NumPy wheel for win32
-        #- cp312*win32
         - cp312*win_amd64
-      # Required so that cp312 can grab a pre-release numpy.
-      # Can remove when cp312 is released.
-      env: |
-        CIBW_ENVIRONMENT: PIP_PRE=1
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,6 @@ requires = [
     "setuptools",
     "setuptools_scm>=6.2,<8",
     "jinja2>=2.10.3",
-    "numpy>=1.25,<2; python_version<'3.12'",
-
-    # For Python versions which aren't yet officially supported, we specify an
-    # unpinned NumPy which allows source distributions to be used and allows
-    # wheels to be used as soon as they become available.
-    "numpy>=1.26.0b1; python_version>='3.12'"
+    "numpy>=1.25,<2"
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Just to see what happens.

Blocked by:

* #115 