### PR TITLE
TMP: Pin setuptools_scm<8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "setuptools_scm>=6.2",
+    "setuptools_scm>=6.2,<8",
     "jinja2>=2.10.3",
     "numpy>=1.25,<2; python_version<'3.12'",
 


### PR DESCRIPTION
Until compatibility with setuptools_scm 8 can be fixed properly.