### PR TITLE
Update liberfa to v2.0.1 and prepare for release.                                                                                            

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
-2.0.0.4 (unreleased)
-====================
+2.0.1 (2023-11-13)
+==================
 
+- Bundled liberfa version update to v2.0.1, which is derived from SOFA
+  version 19 (20231011), which has a few bug fixes.
 - Fix dangling pointer leading to unexpected behavior with ``-O3``.
+- PyERFA now only uses the Python limited API.
+- Ensure things work under python 3.12 and recent setuptools-scm.
 
 2.0.0.3 (2023-03-22)
 ====================


### PR DESCRIPTION
This is effectively the 2.0.1 release, but running it through tests first.

Because of a bugfix of `pvstar` in SOFA, one of the astropy tests fails with it. We should check how to handle that before actually releasing this.