### PR TITLE
Fix PyPy compilation

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -129,13 +129,18 @@ jobs:
         - cp3*-manylinux_x86_64
         - cp3*-musllinux_x86_64
         - cp3*-manylinux_aarch64
+        - pp3*-manylinux_x86_64
+        - pp3*-manylinux_aarch64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
         - cp3*macosx_x86_64
         - cp3*macosx_arm64
+        - pp3*macosx_x86_64
+        - pp3*macosx_arm64
         # Windows wheels
         - cp3*win32
         - cp3*win_amd64
+        - pp3*win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -129,18 +129,16 @@ jobs:
         - cp3*-manylinux_x86_64
         - cp3*-musllinux_x86_64
         - cp3*-manylinux_aarch64
-        - pp3*-manylinux_x86_64
-        - pp3*-manylinux_aarch64
+        - pp39-manylinux_x86_64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         # Note that the arm64 wheels are not actually tested so we
         # rely on local manual testing of these to make sure they are ok.
         - cp3*macosx_x86_64
         - cp3*macosx_arm64
-        - pp3*macosx_x86_64
-        - pp3*macosx_arm64
+        - pp39-macosx_x86_64
         # Windows wheels
         - cp3*win32
         - cp3*win_amd64
-        - pp3*win_amd64
+        - pp39-win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -24,9 +24,11 @@
 // As mentioned in https://github.com/numpy/numpy/issues/16970,
 // the workaround is to define a fake _typeobject struct.
 
-struct _typeobject {
+#ifndef PYPY_VERSION
+typedef struct _typeobject {
     int dummy;
 };
+#endif
 
 #define MODULE_DOCSTRING \
     "Ufunc wrappers of the ERFA routines.\n\n" \


### PR DESCRIPTION
When compiling with PyPy, it looks like _typeobject is already defined by PyPy itself - this causes the conda-forge build to fail since it includes PyPy builds: https://github.com/conda-forge/pyerfa-feedstock/pull/31/checks?check_run_id=17819660419

This PR does the simple fix of making sure we don't redefine _typeobject if we are using PyPy which should be harmless for CPython.

I'm also adding PyPy wheels here to see if they are fast enough to build as this would be a good regression test in itself and would also be nice to provide PyPy wheels.