### PR TITLE
Remove numpy version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools",
     "setuptools_scm>=6.2",
     "jinja2>=2.10.3",
-    "numpy>=1.25,<2"
+    "numpy"
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Test to see if our build machinery actually needs the numpy version constraint, or whether it picks up the more recent (and thus right) version anyway.