### PR TITLE
Build nightly wheels against the latest developer version of Numpy

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -115,30 +115,3 @@ jobs:
         python -m pip install --editable .[test]
         (nm -u erfa/ufunc.*.so | grep eraA2af) || exit 1
         (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || python -m pytest
-
-
-  build_and_publish:
-
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
-    with:
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') }}
-      test_extras: test
-      test_command: pytest --pyargs erfa
-      targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        - cp3*-musllinux_x86_64
-        - cp3*-manylinux_aarch64
-        - pp39-manylinux_x86_64
-        # MacOS X wheels - we deliberately do not build universal2 wheels.
-        # Note that the arm64 wheels are not actually tested so we
-        # rely on local manual testing of these to make sure they are ok.
-        - cp3*macosx_x86_64
-        - cp3*macosx_arm64
-        - pp39-macosx_x86_64
-        # Windows wheels
-        - cp3*win32
-        - cp3*win_amd64
-        - pp39-win_amd64
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Wheel building
+
+on:
+  schedule:
+    # run every day at 4am UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+
+  build_and_publish:
+
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    if: (github.repository == 'liberfa/pyerfa')
+    with:
+
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && github.event_name == 'push' }}
+      upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      anaconda_user: liberfa
+      anaconda_package: pyerfa
+      anaconda_keep_n_latest: 10
+
+      # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
+      # the build isolation and explicitly install the latest developer version of numpy as well as
+      # the latest stable versions of all other build-time dependencies.
+      env: |
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm jinja2 numpy>=0.0.dev0') || '' }}'
+        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
+
+      test_extras: test
+      test_command: pytest --pyargs erfa
+
+      targets: |
+        # Linux wheels
+        - cp3*-manylinux_x86_64
+        - cp3*-musllinux_x86_64
+        - cp3*-manylinux_aarch64
+        - pp39-manylinux_x86_64
+        # MacOS X wheels - we deliberately do not build universal2 wheels.
+        # Note that the arm64 wheels are not actually tested so we
+        # rely on local manual testing of these to make sure they are ok.
+        - cp3*macosx_x86_64
+        - cp3*macosx_arm64
+        - pp39-macosx_x86_64
+        # Windows wheels
+        - cp3*win32
+        - cp3*win_amd64
+        - pp39-win_amd64
+
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
+      anaconda_token: ${{ secrets.anaconda_token }}


### PR DESCRIPTION
This enables the building of nightly wheels as we already do for astropy, and also makes sure that these nightly wheels are built against the latest developer version of numpy as done in https://github.com/astropy/astropy/pull/15524

Nightly wheels will be uploaded to anaconda - I've made a new liberfa organization on anaconda.org to host these wheels:

https://anaconda.org/liberfa/dashboard

I can add others to manage this org if you give me your anaconda.org username.