### PR TITLE
Numpy 2.0 compat

### DIFF
--- a/erfa/helpers.py
+++ b/erfa/helpers.py
@@ -14,6 +14,8 @@ from .core import ErfaWarning
 from .ufunc import get_leap_seconds, set_leap_seconds, dt_eraLEAPSECOND
 
 
+NUMPY_LT_2_0 = np.__version__.startswith("1.")
+
 _NotFound = object()
 
 
@@ -269,8 +271,8 @@ class leap_seconds:
         if hasattr(table, '__array__'):
             table = table.__array__()[list(dt_eraLEAPSECOND.names)]
 
-        table = np.array(table, dtype=dt_eraLEAPSECOND, copy=False,
-                         ndmin=1)
+        table = np.array(table, dtype=dt_eraLEAPSECOND, ndmin=1,
+                         copy=False if NUMPY_LT_2_0 else None)
 
         # Simple sanity checks.
         if table.ndim > 1:

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -572,7 +572,9 @@ static int ErfaUFuncTypeResolver(PyUFuncObject *ufunc,
 {
     int *types;
     PyArray_Descr **dtypes;
-    int types_array[NPY_MAXARGS];
+
+    /* This array needs to be at least as long as nint+nout. In practice, 32 suffices */
+    int types_array[32];
 
     if (ufunc->userloops) {
         Py_ssize_t unused_pos = 0;
@@ -752,7 +754,10 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     PyArray_Descr *dt_ymdf = NULL, *dt_hmsf = NULL, *dt_dmsf = NULL;
     PyArray_Descr *dt_sign = NULL, *dt_type = NULL;
     PyArray_Descr *dt_eraASTROM = NULL, *dt_eraLDBODY = NULL;
-    PyArray_Descr *dtypes[NPY_MAXARGS];
+
+    /* This array needs to be at least as long as nint+nout. In practice, 32 suffices */
+    PyArray_Descr *dtypes[32];
+
     /* ufuncs and their definitions */
     int status;
     PyUFuncObject *ufunc;

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,10 @@ deps =
 extras =
     test
 
+install_command =
+    !devdeps: python -I -m pip install
+    devdeps: python -I -m pip install -v --pre
+
 commands =
     pip freeze
     python -c 'import erfa'  # To give useful error message if liberfa is too old.


### PR DESCRIPTION
This combines a fix to `tox.ini` to allow dev-deps to work (same as is used by astropy) with the fixes from #134 and #135 (former by just including the commit). cc @neutrinoceros

fixes #133
fixes #134
fixes #135