### PR TITLE
BLD: require numpy>=2.0.0rc1 at compile time

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -17,11 +17,6 @@
 #include "erfa.h"
 #include "erfaextra.h"
 
-// Backported NumPy 2 API (can be removed if numpy 2 is required)
-#if NPY_ABI_VERSION < 0x02000000
-#define PyDataType_ELSIZE(descr) ((descr)->elsize)
-#endif
-
 // On gcc<10 we can run into the following:
 //
 //   error: dereferencing pointer to incomplete type 'PyTypeObject'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools",
     "setuptools_scm>=6.2",
     "jinja2>=2.10.3",
-    "numpy"
+    "numpy>=2.0.0rc1",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
As discussed in #143

This isn't just for the sake of following guidelines: it's actually helpful to anyone that would build pyerfa from source *and* would like to easily switch back and forth between versions of numpy, which, if we can't have pre-built wheels for macOS AMD (see https://github.com/liberfa/pyerfa/pull/143#issuecomment-2028825907), includes me 😅 