### PR TITLE
BLD: reintroduce compatibility shim for compiling against numpy 1.x

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -115,3 +115,35 @@ jobs:
         python -m pip install --editable .[test]
         (nm -u erfa/ufunc.*.so | grep eraA2af) || exit 1
         (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || python -m pytest
+
+
+  build_against_numpy_1:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        # this is mainly meant to be useful on old or exotic archs
+        # so we use our oldest-supported Python
+        python-version: '3.9'
+    - name: Install build-time dependencies
+      run: |
+        python -m pip install --upgrade wheel setuptools setuptools_scm jinja2 'numpy<2.0'
+    - run: python -m pip list
+    - name: Build
+      # using --no-build-isolation allows us to skip pass build-system metadata
+      # from pyproject.toml
+      # In particular this allows us to use an older version of numpy than we
+      # normally require.
+      # building in --editable mode to avoid PYTHONPATH issues
+      run: |
+        python -m pip install --editable . --no-build-isolation
+
+    - name: Check
+      run: python -c "import erfa"

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -17,6 +17,11 @@
 #include "erfa.h"
 #include "erfaextra.h"
 
+// Backported NumPy 2 API (can be removed if numpy 2 is required)
+#if NPY_ABI_VERSION < 0x02000000
+#define PyDataType_ELSIZE(descr) ((descr)->elsize)
+#endif
+
 // On gcc<10 we can run into the following:
 //
 //   error: dereferencing pointer to incomplete type 'PyTypeObject'


### PR DESCRIPTION
This reverts a cleanup I did rather eagerly in #144, and re-introduces a compatibility shim originally added in #140
Rationale: even if we're now requiring numpy>2.0.0rc in pyproject.toml, this bit of meta data is ignored by pip when installing with `--no-build-isolation`. On old and exotic architectures, where numpy 2.0.0rc1 isn't available, it's not problematic to build against 1.x instead, and can save the (long) time required to build numpy itself (if it even works).
In short, this would replace https://github.com/astropy/astropy/pull/16284
