### PR TITLE
Ensure graphviz is installed for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,8 @@ build:
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-01-01  || true
+  apt_packages:
+    - graphviz
 
 submodules:
   include: all


### PR DESCRIPTION
Currently, our docs are missing the inheritance diagrams - see https://pyerfa.readthedocs.io/en/latest/api.html#class-inheritance-diagram

I had similar problems in my own packages and found that what was needed was to install `graphviz`, so that is added here.