### PR TITLE
BLD: allow building without Py_LIMITED_API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       # the build isolation and explicitly install the latest developer version of numpy as well as
       # the latest stable versions of all other build-time dependencies.
       env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm jinja2 numpy') || '' }}'
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm wheel jinja2 numpy') || '' }}'
         CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
 
       test_extras: test

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -9,6 +9,12 @@
  * to update it.
  */
 
+/*
+Note that this file is restricted to Python's Limited API, but we define the
+corresponding macro dynamically in setup.py so it can be disabled for Python builds
+that do not support it (e.g., 3.13t)
+*/
+
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "Python.h"
 #include "numpy/arrayobject.h"

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -10,7 +10,6 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define Py_LIMITED_API 0x030900f0
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
@@ -29,7 +28,7 @@
 // As mentioned in https://github.com/numpy/numpy/issues/16970,
 // the workaround is to define a fake _typeobject struct.
 
-#ifndef PYPY_VERSION
+#if (defined Py_LIMITED_API) && !(defined PYPY_VERSION)
 typedef struct _typeobject {
     int dummy;
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools",
     "setuptools_scm>=6.2",
+    "wheel",
     "jinja2>=2.10.3",
     "numpy>=2.0.0rc1",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,3 @@ max-line-length = 100
 
 [pycodestyle]
 max-line-length = 100
-
-[bdist_wheel]
-py_limited_api = cp39


### PR DESCRIPTION
This is to address https://github.com/liberfa/pyerfa/issues/152#issuecomment-2231243236
This changes nothing by default but it *allows* building pyerfa without `Py_LIMITED_API` for testing purposes. This is needed to enable testing astropy in free-threaded Python.

Note that I also ran the test suite locally with free-threading (using Python 3.13.0b3 + numpy 2.1.0dev0) and got no errors so this seems like a safe bet.
