### PR TITLE
WHL: upload and test 'nightlies' only once a week

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Wheel building
 
 on:
   schedule:
-    # run every day at 4am UTC
-    - cron: '0 4 * * *'
+    # run every Sunday at 4am UTC
+    - cron: '0 4 * * SUN'
   workflow_dispatch:
   push:
   pull_request:


### PR DESCRIPTION
As discussed in #154 
I picked Sunday because it conveniently is ~1 day before astropy's weekly cron, so it's less likely that issues get discovered downstream instead of here.

Failures are expected until #155 and #156 are merged

cc @mhvk 