### PR TITLE
BLD: prefer to use bdist_wheel from setuptools rather than wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,14 @@ import setuptools
 import subprocess
 from warnings import warn
 import packaging.version
-from wheel.bdist_wheel import bdist_wheel
 import sysconfig
+
+try:
+    # First available on setuptools 70.1 from January 2024
+    # https://setuptools.pypa.io/en/stable/history.html#v70-1-0
+    from setuptools.command.bdist_wheel import bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel
 
 
 LIBERFADIR = os.path.join('liberfa', 'erfa')


### PR DESCRIPTION
Due to upcoming changes to
setuptools (https://github.com/pypa/setuptools/pull/4647) using bdist_wheel from wheel will fail.

I suspect that this could be simplified by setting a high enough floor on setuptools and dropping wheel as build dependencies, but I am not sure how the window of support of bdist_wheel in setuptools maps to your window of versions of setuptools you want to support.