### PR TITLE
MNT: bump ubuntu image (20.04 -> 22.04)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -23,7 +23,7 @@ jobs:
         include:
 
           - name: Test with oldest supported versions of our dependencies
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             python: 3.9
             toxenv: test-oldestdeps
             toxargs: -v


### PR DESCRIPTION
The `ubuntu-20.04` image is discontinued. Bumping to the oldest image still available.