### PR TITLE
BLD: avoid direct dependency on wheel library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=77.0.0",
     "setuptools_scm>=8.0.0",
-    "wheel",
     "jinja2>=2.10.3",
     "numpy>=2.0.0rc1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,6 @@ from warnings import warn
 import packaging.version
 import sysconfig
 
-try:
-    # First available on setuptools 70.1 from January 2024
-    # https://setuptools.pypa.io/en/stable/history.html#v70-1-0
-    from setuptools.command.bdist_wheel import bdist_wheel
-except ImportError:
-    from wheel.bdist_wheel import bdist_wheel
-
 
 LIBERFADIR = os.path.join('liberfa', 'erfa')
 ERFA_SRC = os.path.join(LIBERFADIR, 'src')
@@ -31,15 +24,11 @@ GEN_FILES = [
 # support the limited API in py313t)
 USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
 
-class bdist_wheel_abi3(bdist_wheel):
-    def get_tag(self):
-        python, abi, plat = super().get_tag()
+if USE_PY_LIMITED_API:
+    options = {"bdist_wheel": {"py_limited_api": "cp39"}}
+else:
+    options = {}
 
-        if USE_PY_LIMITED_API and python.startswith("cp"):
-            # on CPython, our wheels are abi3 and compatible back to 3.9
-            return "cp39", "abi3", plat
-
-        return python, abi, plat
 
 def newer(source, target):
     import pathlib
@@ -204,5 +193,5 @@ use_scm_version = {
 setuptools.setup(
     use_scm_version=use_scm_version,
     ext_modules=get_extensions(),
-    cmdclass={"bdist_wheel": bdist_wheel_abi3},
+    options=options,
 )


### PR DESCRIPTION
A quick follow up to #158 after [the canonical example](https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py) (as [documented by `cibuildwheel`](https://cibuildwheel.pypa.io/en/stable/faq/#abi3)) was simplified.