### PR TITLE
Remove `classproperty`

### DIFF
--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -6,4 +6,4 @@ from .version import version as __version__  # noqa
 from .core import *  # noqa
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND,  # noqa
                     dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
-from .helpers import leap_seconds  # noqa
+from .helpers import *  # noqa


### PR DESCRIPTION
My goal is to get rid of `classproperty`, which is only used by the `leap_seconds` class. With my patch `leap_seconds` is not a class anymore but an instance of the `LeapSeconds` class. Running the tests didn't reveal any problems.