### PR TITLE
Freethreading

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -52,7 +52,7 @@ jobs:
           - name: Test with freethreaded python
             os: ubuntu-latest
             python: '3.14t'
-            toxenv: test-devdeps
+            toxenv: test-freethreaded
             toxargs: -v
 
           - name: Documentation build

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -55,12 +55,6 @@ jobs:
             toxenv: test-devdeps
             toxargs: -v
 
-          - name: Code style checks
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
-            toxargs: -v
-
           - name: Documentation build
             os: ubuntu-latest
             python: 3.x

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -54,6 +54,7 @@ jobs:
             python: '3.14t'
             toxenv: test-freethreaded
             toxargs: -v
+            toxposargs: --parallel-threads=100
 
           - name: Documentation build
             os: ubuntu-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -49,6 +49,14 @@ jobs:
             toxenv: test-devdeps
             toxargs: -v
 
+          - name: Test with freethreaded python
+            os: ubuntu-latest
+            python: '3.14t'
+            toxenv: test-devdeps
+            toxargs: -v
+
+          - name: Code style checks
+            os: ubuntu-latest
           - name: Code style checks
             os: ubuntu-latest
             python: 3.x

--- a/erfa/leap_seconds.py
+++ b/erfa/leap_seconds.py
@@ -25,6 +25,7 @@ but it cannot be used as a context manager.
 
 __all__ = ["get", "set", "update", "validate"]
 
+import threading
 from datetime import datetime, timedelta
 from warnings import warn
 
@@ -43,6 +44,10 @@ def __getattr__(name):
         return _expires_property()
     if name == "expired":
         return _expires_property() < datetime.now()
+    if name == "_expires":
+        return _expiration_data.expires
+    if name == "_expiration_days":
+        return _expiration_data.days
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -50,10 +55,15 @@ def __dir__():
     return ["expired", "expires", "get", "set", "update", "validate"]
 
 
-_expires = None
-"""Explicit expiration date inferred from leap-second table."""
-_expiration_days = 180
-"""Number of days beyond last leap second at which table expires."""
+class _ExpirationData(threading.local):
+    def __init__(self):
+        # Explicit expiration date inferred from leap-second table.
+        self.expires = None
+        # Number of days beyond last leap second at which table expires.
+        self.days = 180
+
+
+_expiration_data = _ExpirationData()
 
 
 def get():
@@ -155,14 +165,13 @@ def set(table=None):
         If the leap seconds in the table are not on the 1st of January or
         July, or if the sorted TAI-UTC do not increase in increments of 1.
     """
-    global _expires
     if table is None:
         expires = None
     else:
         table, expires = validate(table)
 
     set_leap_seconds(table)
-    _expires = expires
+    _expiration_data.expires = expires
 
 
 def _expires_property():
@@ -172,12 +181,12 @@ def _expires_property():
     set the leap-second array, or a number of days beyond the last leap
     second.
     """
-    if _expires is None:
+    if _expiration_data.expires is None:
         last = get()[-1]
         return (datetime(last["year"], last["month"], 1) +
-                timedelta(_expiration_days))
+                timedelta(_expiration_data.days))
     else:
-        return _expires
+        return _expiration_data.expires
 
 
 def update(table):
@@ -207,7 +216,6 @@ def update(table):
         If the leap seconds in the table are not on the 1st of January or
         July, or if the sorted TAI-UTC do not increase in increments of 1.
     """
-    global _expires
     table, expires = validate(table)
 
     # Get erfa table and check it is OK; if not, reset it.
@@ -226,7 +234,7 @@ def update(table):
     # array is set, do not allow exceptions due to misformed expires).
     try:
         if expires is not None and expires > _expires_property():
-            _expires = expires
+            _expiration_data.expires = expires
 
     except Exception as exc:
         warn("table 'expires' attribute ignored as comparing it "

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -21,6 +21,7 @@ that do not support it (e.g., 3.13t)
 #include "numpy/ufuncobject.h"
 #include "erfa.h"
 #include "erfaextra.h"
+#include "erfadatextra.h"
 
 // Backported NumPy 2 API (can be removed if numpy 2 is required)
 #if NPY_ABI_VERSION < 0x02000000
@@ -684,7 +685,7 @@ static PyObject *
 set_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *args) {
     PyObject *leap_seconds = NULL;
     PyArrayObject *array;
-    static PyArrayObject *leap_second_array = NULL;
+    static ERFA_THREAD_LOCAL PyArrayObject *leap_second_array = NULL;
 
     if (!PyArg_ParseTuple(args, "|O:set_leap_seconds", &leap_seconds)) {
         return NULL;
@@ -790,6 +791,10 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     if (m == NULL) {
         return NULL;
     }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     d = PyModule_GetDict(m); /* borrowed ref. */
     if (d == NULL) {
         goto fail;

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -685,7 +685,11 @@ static PyObject *
 set_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *args) {
     PyObject *leap_seconds = NULL;
     PyArrayObject *array;
-    static ERFA_THREAD_LOCAL PyArrayObject *leap_second_array = NULL;
+    # ifdef ERFA_THREAD_LOCAL
+      static ERFA_THREAD_LOCAL PyArrayObject *leap_second_array = NULL;
+    # else
+      static PyArrayObject *leap_second_array = NULL;
+    # endif
 
     if (!PyArg_ParseTuple(args, "|O:set_leap_seconds", &leap_seconds)) {
         return NULL;
@@ -791,8 +795,11 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     if (m == NULL) {
         return NULL;
     }
+// FIXME: also require ERFA_HAS_THREAD_LOCAL
 #ifdef Py_GIL_DISABLED
+  # ifdef ERFA_THREAD_LOCAL
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+  # endif
 #endif
 
     d = PyModule_GetDict(m); /* borrowed ref. */

--- a/tox.ini
+++ b/tox.ini
@@ -68,4 +68,3 @@ extras = docs
 commands =
     pip freeze
     sphinx-build -W -b linkcheck . _build/html
-

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,13 @@ description =
     run tests
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
+    freethreaded: with multi-threaded tests and a free-threaded python build
 
 # The following provides some specific pinnings for key packages
 deps =
     oldestdeps: numpy==1.21.*
     devdeps: numpy>=0.0.dev0
+    freethreaded: pytest-run-parallel
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
@@ -66,3 +68,4 @@ extras = docs
 commands =
     pip freeze
     sphinx-build -W -b linkcheck . _build/html
+

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
 
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    freethreaded: PYTHON_GIL = 0
 
 # Run the tests in a temporary directory to make sure that we don't import
 # pyerfa from the source tree


### PR DESCRIPTION
The changes I needed were

- making erfa leap seconds thread safe
- making the leap second expiration global variables thread local
- I tested the impure `aper` functions, but those seem to not actually modify the input in place in pyerfa, so those are safe as far as I can tell.

I ran all of the tests with [pytest-run-parallel](https://github.com/quansight-labs/pytest-run-parallel) and they pass (except the docstring test, which pytest-run-parallel can't handle).

Remaining questions I have:

- should I write something up in the docs somewhere?
- I added a py314t test to the CI suite, is that alright? Should I add more tests?

See https://github.com/liberfa/pyerfa/issues/209 cc @neutrinoceros @mhvk 

Needs https://github.com/liberfa/erfa/pull/108.