### PR TITLE
Remove an inactive check for source distribution builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,8 +114,6 @@ def get_extensions():
         if config_h.exists():
             include_dirs.append(LIBERFADIR)
             define_macros.append(('HAVE_CONFIG_H', '1'))
-        elif 'sdist' in sys.argv:
-            raise RuntimeError('missing "configure" script in "liberfa/erfa"')
 
     if USE_PY_LIMITED_API:
         define_macros.append(("Py_LIMITED_API", "0x30900f0"))


### PR DESCRIPTION
`setup.py` is meant to raise a `RuntimeError` if a `pyerfa` source distribution is being built and `liberfa` `config.h` is not present and cannot be created, but the check
```python
"sdist" in sys.argv
```
is for the deprecated
```
python setup.py sdist
```
command. [The modern command for building only a source distribution](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-commands-should-be-used-instead) is
```
python -m build --sdist
```
which would allow checking for
```python
"--sdist" in sys.argv
```
but a source distribution can also built together with a wheel by the
```
python -m build
```
 command, and checking for
```python
"build" in sys.argv
```
would also detect
```
python -m build --wheel
```
which has nothing to do with source distributions. Given that nobody has noticed the check in question becoming inactive it should be safe to remove entirely.