### PR TITLE
Remove a warning about `erfa` not being installed

### DIFF
--- a/erfa/version.py
+++ b/erfa/version.py
@@ -1,15 +1,6 @@
 """Wrapper, ERFA and SOFA version information."""
 
-try:
-    from ._version import version as _version
-except Exception:
-    import warnings
-    warnings.warn(
-        f'could not determine {__name__.split(".")[0]} package version; '
-        f'this indicates a broken installation')
-    del warnings
-
-    _version = '0.0.0'
+from ._version import version as _version
 
 # Set the version numbers a bit indirectly, so that Sphinx can pick up
 # up the docstrings and list the values.


### PR DESCRIPTION
The `pyerfa` repository uses flat layout, which means trying to import `erfa` without having installed it is not guaranteed to crash immediately. A warning is meant to inform the user about `erfa` not being installed, but if that failure mode is worth worrying about then it should be addressed properly by using src-layout instead.

For more details see https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/