### PR TITLE
Make code calling `get_liberfa_versions()` clearer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ if USE_PY_LIMITED_API:
     options["bdist_wheel"] = {"py_limited_api": "cp310"}
 
 
-def get_liberfa_versions(path=LIBERFADIR / "configure.ac"):
+def get_liberfa_versions(
+    path: Path = LIBERFADIR / "configure.ac",
+) -> list[tuple[str, int | str]]:
     s = path.read_text()
 
     mobj = re.search(r'AC_INIT\(\[erfa\],\[(?P<version>[0-9.]+)\]\)', s)
@@ -102,14 +104,12 @@ def get_extensions():
                 warn(f'unable to configure liberfa: {exc}')
 
         if not config_h.exists():
-            liberfa_versions = get_liberfa_versions()
-            if liberfa_versions:
+            if version_definitions := "\n".join(
+                f"#define {name} {value!r}".replace("'", '"')
+                for name, value in get_liberfa_versions()
+            ):
                 print('Configure liberfa ("configure.ac" scan)')
-                lines = []
-                for name, value in liberfa_versions:
-                    # making sure strings are correctly quoted
-                    lines.append(f'#define {name} {value!r}'.replace("'", '"'))
-                config_h.write_text("\n".join(lines))
+                config_h.write_text(version_definitions)
             else:
                 warn('unable to get liberfa version')
 


### PR DESCRIPTION
I had some trouble understanding why current `main` has the code https://github.com/liberfa/pyerfa/blob/2d9b3cdfadaa115c00399cc506c136a8121d5fa1/setup.py#L110-L111 instead of the much simpler
```python
lines.append(f'#define {name} "{value}"')
```
Eventually I realized it is because the return type of `get_liberfa_versions()` is not `list[tuple[str, str]]` like I had thought in the beginning, but instead it is `list[tuple[str, int | str]]`, and the more complicated code in current `main` ensures the `int` and `str` values are handled differently. This PR both simplifies the code where `get_liberfa_versions()` is called and also adds type annotations to the function to make its return type explicit.