### PR TITLE
Simplify `erfa_generator.main()` signature

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -657,7 +657,7 @@ def _assemble_py_func_call(name: str, in_args: list[str], out_args: list[str]) -
     return f"{', '.join(out_args)} = {name}({', '.join(in_args)})"
 
 
-def main(srcdir=DEFAULT_ERFA_LOC, templateloc=DEFAULT_TEMPLATE_LOC):
+def main(srcdir: Path, templateloc: Path) -> None:
     from jinja2 import Environment, FileSystemLoader
 
     outfn = 'core.py'
@@ -706,21 +706,17 @@ def main(srcdir=DEFAULT_ERFA_LOC, templateloc=DEFAULT_TEMPLATE_LOC):
             )
         )
 
-    erfa_c = env.get_template(ufuncfn + ".templ").render(funcs=funcs)
-    erfa_py = env.get_template(outfn + ".templ").render(
-        funcs=funcs, constants=constants
+    (templateloc / outfn).write_text(
+        env.get_template(outfn + ".templ").render(funcs=funcs, constants=constants)
     )
-    test_py = (
+    (templateloc / ufuncfn).write_text(
+        env.get_template(ufuncfn + ".templ").render(funcs=funcs)
+    )
+    (templateloc / testdir / testfn).write_text(
         Environment(loader=FileSystemLoader(templateloc / testdir))
         .get_template(testfn + ".templ")
         .render(test_funcs=test_funcs)
     )
-
-    (templateloc / outfn).write_text(erfa_py)
-    (templateloc / ufuncfn).write_text(erfa_c)
-    (templateloc / testdir / testfn).write_text(test_py)
-
-    return erfa_c, erfa_py, funcs, test_py, test_funcs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I am proposing we simplify the signature of `erfa_generator.main()`. The changes can be breaking if `erfa_generator` is imported as a module and `main()` is called directly, but I don't think anybody does that. The changes do retain full backwards compatibility if `erfa_generator` is executed as a script.

On the input side I am removing the default values from the `main()` function `srcdir` and `templateloc` parameters. They are not needed when `erfa_generator` runs as a script because then `main()` is always called with explicit arguments for which the default values are provided by the command line argument parser. It is better to avoid defining defaults twice.

On the output side I find it very surprising that on current `main` branch the `main()` function returns a tuple. My expectation is that a `main()` function will either implicitly return `None` or explicitly return a status code as an `int` (see also https://docs.python.org/3.10/library/__main__.html#packaging-considerations although that documentation is about scripts that are installed together with the package, and that is not exactly the use case here). Furthermore, returning `None` instead of a tuple allows eliminating a few local variables and shortening the code.