### PR TITLE
Fix the completely broken `erfa.tpors()` and `erfa.tporv()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 ====================
 - Let multi-output functions now return a ``namedtuple`` so that
   the various results can be accessed by attribute. [gh-176]
+- The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
+  unavoidable ``KeyError``. [gh-234]
 
 2.0.1.6 (2025-01-27)
 ====================

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -113,11 +113,9 @@ dt_bytes12 = np.dtype('S12')
  # Define the status codes that this function returns.
  #}
 {%- for stat in func.args_by_inout('stat') %}
-{%- if stat.statuscodes %}
 
 
-STATUS_CODES['{{ func.pyname }}'] = {{ stat.statuscodes.to_python() }}
-{%- endif %}
+STATUS_CODES['{{ func.pyname }}'] = {{ stat.to_python() }}
 {%- endfor %}
 {#-
  # For ufuncs with more than one output, define a namedtuple so one

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -369,7 +369,6 @@ def test_non_contiguous_output_matrix():
     assert_array_equal(expected, result)
 
 
-@pytest.mark.xfail(raises=KeyError, reason="regression test to demonstrate a bug")
 @pytest.mark.parametrize(
     ("func", "kwargs"),
     [

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -369,6 +369,22 @@ def test_non_contiguous_output_matrix():
     assert_array_equal(expected, result)
 
 
+@pytest.mark.xfail(raises=KeyError, reason="regression test to demonstrate a bug")
+@pytest.mark.parametrize(
+    ("func", "kwargs"),
+    [
+        pytest.param(erfa.tpors, {"a": 1.3, "b": 1.5}, id="tpors"),
+        pytest.param(
+            erfa.tporv, {"v": [0.01892212, 0.06815941, 0.99749499]}, id="tporv"
+        ),
+    ],
+)
+def test_int_return_values(func, kwargs):
+    # Regression test for #234 - tpors() and tporv() return an integer, but that integer
+    # is not a status code and it should not be passed to check_errwarn().
+    assert func(-0.03, 0.07, **kwargs).c_retval == 2
+
+
 class TestAstromNotInplace:
     def setup_method(self):
         self.mjd_array = np.array(

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -129,7 +129,7 @@ class ArgumentDoc:
 
 
 class Variable:
-    """Properties shared by Argument and Return."""
+    """Properties shared by Argument, Return and StatusCode."""
     @property
     def npy_type(self):
         """Predefined type used by numpy ufuncs to indicate a given ctype.
@@ -257,14 +257,28 @@ class Argument(Variable):
         return ("_" if self.is_ptr else "*_") + self.name
 
 
-class StatusCodes:
-    def __init__(self, source: str) -> None:
+class StatusCode(Variable):
+    def __init__(self, ctype: str, doc: FunctionDoc, funcname: str) -> None:
+        self.name = "c_retval"
+        self.inout_state = "stat"
+        self.ctype = "int"
+        self.shape = ()
+
+        status = re.search(
+            r"Returned \(function value\):\n\s+\w+\s+status.*?:(.+?)\s+Notes?:",
+            doc.doc,
+            re.DOTALL,
+        )
+        if status is None:
+            raise RuntimeError(
+                f"cannot find status code description in {funcname} doc comment"
+            )
         self._statuscodes: Final = {
             "else" if code == "else" else int(code): " ".join(
                 line.strip() for line in description.splitlines()
             )
             for code, description in re.findall(
-                r"(-?\w+) = ((?:[^=]+$)+)", source, re.MULTILINE
+                r"(-?\w+) = ((?:[^=]+$)+)", status.group(1), re.MULTILINE
             )
         }
 
@@ -278,16 +292,9 @@ class Return(Variable):
 
     def __init__(self, ctype, doc):
         self.name = 'c_retval'
-        self.inout_state = 'stat' if ctype == 'int' else 'ret'
+        self.inout_state = "ret"
         self.ctype = ctype
         self.shape = ()
-
-        status = re.search(
-            r"Returned \(function value\):\n\s+\w+\s+status.*?:(.+?)\s+Notes?:",
-            doc.doc,
-            re.DOTALL,
-        )
-        self.statuscodes = None if status is None else StatusCodes(status.group(1))
 
 
 class Function:
@@ -316,7 +323,9 @@ class Function:
         for arg in re.search(r"\(([^)]+)\)", self.cfunc).group(1).split(', '):
             self.args.append(Argument(arg, self.doc))
         self.ret = re.search(f"^(.*){name}", self.cfunc).group(1).strip()
-        if self.ret != 'void':
+        if self.ret == "int" and self.name not in ("eraTpors", "eraTporv"):
+            self.args.append(StatusCode(self.ret, self.doc, name))
+        elif self.ret != "void":
             self.args.append(Return(self.ret, self.doc))
 
     def args_by_inout(self, inout_filter):


### PR DESCRIPTION
At least in current `main` and in v2.0.1.6 `erfa_generator` assumes that because `eraTpors()` and `eraTporv()` return an integer then that integer must be a status code, and has therefore generated code in `erfa.tpors()` and `erfa.tporv()` that passes the return value to `check_errwarn()`. But because `erfa_generator` has not been able to find the status code descriptions in the C function doc comments then it has not generated the code for the status code dictionaries `check_errwarn()` requires. Trying to fetch those dictionaries therefore causes an unavoidable `KeyError`, as revealed by the new tests in the first commit. The two functions in question do return an integer, but it is not a status code, so passing it to `check_errwarn()` is the wrong thing to do.

The second commit updates `erfa_generator` so that it no longer assumes that the two C functions return a status code, making the Python wrappers usable. Furthermore, a new check in `erfa_generator` raises an error if it cannot find the status code descriptions in C doc comments it is looking for, which prevents this kind of problem from going unnoticed in the future.