### PR TITLE
Fix `erfa.cal2jd()` with scalar non-zero status codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
   the various results can be accessed by attribute. [gh-176]
 - The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
   unavoidable ``KeyError``. [gh-234]
+- ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an
+  ``ErfaError`` or ``ErfaWarning`` if all its inputs are scalars.
 
 2.0.1.6 (2025-01-27)
 ====================

--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -66,15 +66,15 @@ STATUS_CODES_REMAP = {
 def check_errwarn(statcodes, func_name):
     if not np.any(statcodes):
         return
+    statcodes = np.atleast_1d(statcodes)
     # Remap any errors into warnings in the STATUS_CODES_REMAP dict.
     if func_name in STATUS_CODES_REMAP:
         for before, after in STATUS_CODES_REMAP[func_name].items():
             statcodes[statcodes == before] = after
             STATUS_CODES[func_name][after] = STATUS_CODES[func_name][before]
 
-    # Use non-zero to be able to index (need >=1-D for this to work).
+    # Use non-zero to be able to index.
     # Conveniently, this also gets rid of any masked elements.
-    statcodes = np.atleast_1d(statcodes)
     erridx = (statcodes < 0).nonzero()
     if erridx[0].size > 0:
         # Errors present - only report the errors.

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 import erfa
+from erfa import ErfaError, ErfaWarning
 
 try:
     from astropy.time import Time
@@ -382,6 +383,22 @@ def test_int_return_values(func, kwargs):
     # Regression test for #234 - tpors() and tporv() return an integer, but that integer
     # is not a status code and it should not be passed to check_errwarn().
     assert func(-0.03, 0.07, **kwargs).c_retval == 2
+
+
+@pytest.mark.xfail(raises=TypeError, reason="regression test to reveal a bug")
+def test_scalar_cal2jd_error():
+    # Regression test for #235 - scalar non-zero status codes in cal2jd caused a
+    # TypeError instead of ErfaError or ErfaWarning. This only affected cal2jd because
+    # it is the only function with a corresponding entry in erfa.core.STATUS_CODES_REMAP
+    with pytest.raises(ErfaError, match="bad month"):
+        erfa.cal2jd(2026, 26, 26)
+
+
+@pytest.mark.xfail(reason="regression test to reveal a bug")
+def test_scalar_cal2jd_warning():
+    # See test_scalar_cal2jd_error
+    with pytest.warns(ErfaWarning, match="bad day"):
+        erfa.cal2jd(2026, 11, 2026)
 
 
 class TestAstromNotInplace:

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -385,7 +385,6 @@ def test_int_return_values(func, kwargs):
     assert func(-0.03, 0.07, **kwargs).c_retval == 2
 
 
-@pytest.mark.xfail(raises=TypeError, reason="regression test to reveal a bug")
 def test_scalar_cal2jd_error():
     # Regression test for #235 - scalar non-zero status codes in cal2jd caused a
     # TypeError instead of ErfaError or ErfaWarning. This only affected cal2jd because
@@ -394,7 +393,6 @@ def test_scalar_cal2jd_error():
         erfa.cal2jd(2026, 26, 26)
 
 
-@pytest.mark.xfail(reason="regression test to reveal a bug")
 def test_scalar_cal2jd_warning():
     # See test_scalar_cal2jd_error
     with pytest.warns(ErfaWarning, match="bad day"):


### PR DESCRIPTION
The first commit demonstrates that if `erfa.cal2jd()` is called with scalar inputs and it should raise an `ErfaError` or an `ErfaWarning` then it raises an unexpected `TypeError` instead. The bug only affects `erfa.cal2jd()` because that is the only function that has its status codes remapped in `check_errwarn()`. It is entirely mysterious to me why this status code remapping mechanism exists at all and the bug could be solved by removing it, but in the second commit I nonetheless fix the bug in a way that retains the remapping.