### PR TITLE
Fix doc comment pre-processing in `erfa_generator`

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -20,12 +20,12 @@ DEFAULT_TEMPLATE_LOC = Path(__file__).with_name("erfa")
 
 
 class FunctionDoc:
-
-    def __init__(self, doc):
-        self.doc = doc.replace("**", "      ").replace("/*\n", "").replace("*/", "")
-        self.doc = self.doc.replace("/*+\n", "")        # accommodate eraLdn
-        self.doc = self.doc.replace("*  ", "    " * 2)  # accommodate eraAticqn
-        self.doc = self.doc.replace("*\n", "\n")        # accommodate eraAticqn
+    def __init__(self, doc: str, pyname: str) -> None:
+        if pyname == "ldn":
+            doc = doc.removeprefix("+")
+        elif pyname == "aticqn":
+            doc = doc.replace("\n* ", "\n** ", 2).replace("\n*\n", "\n**\n", 1)
+        self.doc: Final = doc.replace("\n**", "\n      ").removeprefix("\n")
 
     def _get_arg_doc_list(self, doc_lines):
         """Parse input/output doc section lines, getting arguments from them.
@@ -322,11 +322,11 @@ class Function:
         self.name = name
         self.pyname = name.split('era')[-1].lower()
 
-        pattern = fr"\n([^\n]+{name} ?\([^)]+\)).+?(/\*.+?\*/)"
+        pattern = fr"\n([^\n]+{name} ?\([^)]+\)).+?/\*(.+?)\*/"
         p = re.compile(pattern, flags=re.DOTALL | re.MULTILINE)
         search = p.search((source_path / (self.pyname + ".c")).read_text())
         self.cfunc = " ".join(search.group(1).split())
-        self.doc = FunctionDoc(search.group(2))
+        self.doc: Final = FunctionDoc(search.group(2), self.pyname)
 
         self.args = []
         for arg in re.search(r"\(([^)]+)\)", self.cfunc).group(1).split(', '):


### PR DESCRIPTION
There are small peculiarities in the `eraLdn()` and `eraAticqn()` doc comments which are removed in a pre-processing step. However, in current `main` the pre-processing is not specific enough, so it also makes unintentional changes to doc comments of several other functions. As a result the docstrings of the Python wrappers that are supposed to include a copy of the C doc comments erroneously document most pointers as their targets instead. Additionally, the affected lines tend to become misaligned. This PR makes the pre-processing much more specific, which fixes the generated Python docstrings.

The difference between `erfa/core.py` generated by current `main` and this PR is
```diff
821c821
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
1086c1086
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
1223c1223
<            astrom eraASTROM        star-independent astrometry parameters:
---
>            astrom eraASTROM*  star-independent astrometry parameters:
1240c1240
<            eo     double           equation of the origins (ERA-GST, radians)
---
>            eo     double*     equation of the origins (ERA-GST, radians)
1382c1382
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
1603c1603
<            eo     double          equation of the origins (ERA-GST, radians)
---
>            eo     double*    equation of the origins (ERA-GST, radians)
1781c1781
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
1926c1926
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
2054c2054
<            astrom  eraASTROM        star-independent astrometry parameters:
---
>            astrom  eraASTROM*  star-independent astrometry parameters:
2073c2073
<            astrom  eraASTROM        star-independent astrometry parameters:
---
>            astrom  eraASTROM*  star-independent astrometry parameters:
2172c2172
<            astrom  eraASTROM        star-independent astrometry parameters:
---
>            astrom  eraASTROM*  star-independent astrometry parameters:
2191c2191
<            astrom  eraASTROM        star-independent astrometry parameters:
---
>            astrom  eraASTROM*  star-independent astrometry parameters:
2324c2324
<            astrom eraASTROM        star-independent astrometry parameters:
---
>            astrom eraASTROM*  star-independent astrometry parameters:
2485c2485
<            astrom eraASTROM        star-independent astrometry parameters:
---
>            astrom eraASTROM*  star-independent astrometry parameters:
2678c2678
<            ra,da  double        ICRS astrometric RA,Dec (radians)
---
>            ra,da  double*  ICRS astrometric RA,Dec (radians)
2796c2796
<            ra,da  double          ICRS astrometric RA,Dec (radians)
---
>            ra,da  double*    ICRS astrometric RA,Dec (radians)
3086c3086
<            astrom eraASTROM         star-independent astrometry parameters:
---
>            astrom eraASTROM*   star-independent astrometry parameters:
3342,3347c3342,3347
<            aob    double        observed azimuth (radians: N=0,E=90)
<            zob    double        observed zenith distance (radians)
<            hob    double        observed hour angle (radians)
<            dob    double        observed declination (radians)
<            rob    double        observed right ascension (CIO-based, radians)
<            eo     double        equation of the origins (ERA-GST, radians)
---
>            aob    double*  observed azimuth (radians: N=0,E=90)
>            zob    double*  observed zenith distance (radians)
>            hob    double*  observed hour angle (radians)
>            dob    double*  observed declination (radians)
>            rob    double*  observed right ascension (CIO-based, radians)
>            eo     double*  equation of the origins (ERA-GST, radians)
3706c3706
<            astrom eraASTROM        star-independent astrometry parameters:
---
>            astrom eraASTROM*  star-independent astrometry parameters:
3859,3863c3859,3863
<            aob    double        observed azimuth (radians: N=0,E=90)
<            zob    double        observed zenith distance (radians)
<            hob    double        observed hour angle (radians)
<            dob    double        observed declination (radians)
<            rob    double        observed right ascension (CIO-based, radians)
---
>            aob    double*  observed azimuth (radians: N=0,E=90)
>            zob    double*  observed zenith distance (radians)
>            hob    double*  observed hour angle (radians)
>            dob    double*  observed declination (radians)
>            rob    double*  observed right ascension (CIO-based, radians)
4034,4038c4034,4038
<            aob    double          observed azimuth (radians: N=0,E=90)
<            zob    double          observed zenith distance (radians)
<            hob    double          observed hour angle (radians)
<            dob    double          observed declination (radians)
<            rob    double          observed right ascension (CIO-based, radians)
---
>            aob    double*    observed azimuth (radians: N=0,E=90)
>            zob    double*    observed zenith distance (radians)
>            hob    double*    observed hour angle (radians)
>            dob    double*    observed declination (radians)
>            rob    double*    observed right ascension (CIO-based, radians)
4362,4363c4362,4363
<            ri     double        CIRS right ascension (CIO-based, radians)
<            di     double        CIRS declination (radians)
---
>            ri     double*  CIRS right ascension (CIO-based, radians)
>            di     double*  CIRS declination (radians)
4545,4546c4545,4546
<            ri     double          CIRS right ascension (CIO-based, radians)
<            di     double          CIRS declination (radians)
---
>            ri     double*    CIRS right ascension (CIO-based, radians)
>            di     double*    CIRS declination (radians)
5225,5226c5225,5226
<           refa   double         tan Z coefficient (radians)
<           refb   double         tan^3 Z coefficient (radians)
---
>           refa   double*   tan Z coefficient (radians)
>           refb   double*   tan^3 Z coefficient (radians)
5761c5761
<                      C instead of Fortran.
---
>              *  C instead of Fortran.
5763c5763
<                      The date is supplied in two parts.
---
>              *  The date is supplied in two parts.
5765c5765
<                      The result is returned only in equatorial Cartesian form;
---
>              *  The result is returned only in equatorial Cartesian form;
5769c5769
<                      The result is in the J2000.0 equatorial frame, not ecliptic.
---
>              *  The result is in the J2000.0 equatorial frame, not ecliptic.
5771c5771
<                      More is done in-line: there are fewer calls to subroutines.
---
>              *  More is done in-line: there are fewer calls to subroutines.
5773c5773
<                      Different error/warning status values are used.
---
>              *  Different error/warning status values are used.
5775c5775
<                      A different Kepler's-equation-solver is used (avoiding
---
>              *  A different Kepler's-equation-solver is used (avoiding
5778c5778
<                      Polynomials in t are nested to minimize rounding errors.
---
>              *  Polynomials in t are nested to minimize rounding errors.
5780c5780
<                      Explicit double constants are used to avoid mixed-mode
---
>              *  Explicit double constants are used to avoid mixed-mode
19137c19137
<            sign    char         '+' or '-'
---
>            sign    char*   '+' or '-'
19219c19219
<            sign    char         '+' or '-'
---
>            sign    char*   '+' or '-'
19446c19446
<            sign    char         '+' or '-'
---
>            sign    char*   '+' or '-'
```