### PR TITLE
Simplify indenting C doc comments in Python wrapper docstrings

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -157,7 +157,7 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
     | map(attribute='name')|join(', ') }} in-place.
     {%- endif %} The ERFA documentation is::
 
-{{ func.doc }}
+{{ func.doc.doc | indent(6, true) }}
     """
 
     {#-

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -25,11 +25,11 @@ class FunctionDoc:
             doc = doc.removeprefix("+")
         elif pyname == "aticqn":
             doc = doc.replace("\n* ", "\n** ", 2).replace("\n*\n", "\n**\n", 1)
-        self.doc: Final = doc.replace("\n**", "\n      ").removeprefix("\n")
+        self.doc: Final = doc.replace("\n**", "\n").removeprefix("\n")
 
-        inout = self._get_arg_doc_list("Given and returned:\n(.+?) +\n")
-        self.input: Final = self._get_arg_doc_list("Given.*?\n(.+?) +\n") + inout
-        self.output: Final = inout + self._get_arg_doc_list("Returned.*?\n(.+?) +\n")
+        inout = self._get_arg_doc_list("Given and returned:\n(.+?)\n\n")
+        self.input: Final = self._get_arg_doc_list("Given.*?\n(.+?)\n\n") + inout
+        self.output: Final = inout + self._get_arg_doc_list("Returned.*?\n(.+?)\n\n")
 
     def _get_arg_doc_list(self, regex: str) -> list["ArgumentDoc"]:
         """Parse input/output doc section lines, getting arguments from them.
@@ -89,10 +89,6 @@ class FunctionDoc:
                 break
 
         return '\n    '.join(description)
-
-    def __repr__(self):
-        return '\n'.join([(ln.rstrip() if ln.strip() else '')
-                          for ln in self.doc.split('\n')])
 
 
 class ArgumentDoc:


### PR DESCRIPTION
The Python wrappers include C doc comments in their docstrings, which are indented so that they would be simple to distinguish. In current `main` the indentation is performed in `FunctionDoc.__init__()` by left padding all lines in the doc comments, but that also adds whitespace to blank lines, which then has to be removed in `FunctionDoc.__repr__()`. In this PR doc comment indentation is performed by Jinja, which does not add whitespace to blank lines.

There are no changes to the files `erfa_generator` creates.