### PR TITLE
Remove `Argument.view_dtype` property

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -98,7 +98,6 @@ def check_errwarn(statcodes, func_name):
 # <------------------------structured dtype conversion------------------------>
 
 dt_bytes1 = np.dtype('S1')
-dt_bytes12 = np.dtype('S12')
 
 # <--------------------------Actual ERFA-wrapping code------------------------>
 
@@ -175,8 +174,8 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
      # Any string outputs will be in structs; view them as their base type.
      #}
     {%- for arg in func.args_by_inout('out') -%}
-    {%- if 'char' in arg.ctype %}
-    {{ arg.name }} = {{ arg.name }}.view({{ arg.view_dtype }})
+    {%- if arg.ctype == "char" %}
+    {{ arg.name }} = {{ arg.name }}.view(dt_bytes1)
     {%- endif %}
     {%- endfor %}
     {#-

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -176,21 +176,6 @@ class Argument(Variable):
         raise ValueError(f"ctype {self.ctype} with shape {self.shape} not recognized.")
 
     @property
-    def view_dtype(self):
-        """Name of dtype corresponding to the ctype for viewing back as array.
-
-        E.g., dt_double for double, dt_double33 for double[3][3].
-
-        The types are defined in core.py, where they are used for view-casts
-        of structured results as regular arrays.
-        """
-        if self.ctype == 'const char':
-            return 'dt_bytes12'
-        if self.ctype == "char":
-            return 'dt_bytes1'
-        raise ValueError("Only char ctype should need view back!")
-
-    @property
     def ndim(self):
         return len(self.shape)
 


### PR DESCRIPTION
In practice the property has one possible value, so it is simpler to hardcode that value in the `core.py` template.

The full difference between the files generated by `erfa_generator` in current `main` and this PR is
```diff
130d129
< dt_bytes12 = np.dtype('S12')
```