### PR TITLE
Simplify tests generated by erfa_generator.py

### DIFF
--- a/erfa/tests/test_ufunc.py.templ
+++ b/erfa/tests/test_ufunc.py.templ
@@ -11,8 +11,6 @@ Basic tests of the ERFA library routines.
 These are just the tests bundled with ERFA itself, in ``t_erfa_c.c``,
 but translated to python to make sure that the code returns the same numbers.
 
-The viv and vid functions emulate the corresponding functions in ``t_erfa_c.c``.
-
 The tests are skipped if a system library is used that does not match in
 version number, since in that case the precise numbers may have changed
 (e.g., due to the earth orientation changes between 1.7.2 and 1.7.3).
@@ -30,20 +28,6 @@ if not erfa.__version__.startswith(erfa.version.erfa_version):
                 allow_module_level=True)
 
 
-def viv(ival, ivalok, func, test, _):
-    """Validate an integer result."""
-    assert ival == ivalok, f"{func} failed: {test} want {ivalok} got {ival}"
-
-
-def vvd(val, valok, dval, func, test, _):
-    """Validate a double result."""
-    a = val - valok
-    assert a == 0.0 or abs(a) <= abs(dval), (
-        f"{func} failed: {test} want {valok:.20g} got {val:.20g} "
-        f"(1/{abs(valok / a):.3g})")
-
-
-status = np.zeros((), dtype=int)
 # <--------------------------Actual test-wrapping code------------------------>
 {%- for test in test_funcs %}
 
@@ -58,8 +42,4 @@ def test_{{ test.name }}():
 
 
 {%- endfor %}
-
-
-def test_status():
-    assert status == 0, "Sanity check failed!"
 {# done! (note: this comment also ensures final new line!) #}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -478,12 +478,14 @@ class TestFunction:
                     .replace("s, '+'", "s[0], b'+'")  # Rather hacky...
                     .strip())
 
-            # Call of test function vvi or vvd.
-            if line.startswith('v'):
-                line = line.replace(era_name, self.name)
-                # Can call simple functions directly.  Those need little modification.
-                if self.name + '(' in line:
-                    line = line.replace(self.name + '(', f"erfa_ufunc.{self.name}(")
+            if m := re.match(r"viv ?\( ?([\w\[\]]+), +(.+?),", line):
+                line = f"assert {m.group(1)} == {m.group(2)}"
+
+            elif m := re.match(
+                r"vvd\( ?(.+) ?, +([\d\.e-]+), *([\d\.e-]+), .+?, .+?, +status\)", line
+            ):
+                expr = m.group(1).replace(era_name, f"erfa_ufunc.{self.name}")
+                line = f"assert {expr} == pytest.approx({m.group(2)}, abs={m.group(3)})"
 
             # Call of function that is being tested.
             elif era_name in line:


### PR DESCRIPTION
Among other things `erfa_generator.py` translates the `erfa` tests in `t_erfa_c.c` into a Python module that can be tested with `pytest`. So far the translation has tried to change the code as little as possible, but writing Python as if it is ANSI C is not taking advantage of the features Python and `pytest` provide. A less literal translation removes the need for the `viv()` and `vvd()` test helpers and improves tracebacks if a test should fail. For example, with the following change to the `erfa/tests/test_ufunc.py` generated by current `main`
```diff
@@ -3729,7 +3729,7 @@ def test_xys06a():
     x, y, s = erfa_ufunc.xys06a(2400000.5, 53736.0)
     vvd(x,  0.5791308482835292617e-3, 1e-14, "xys06a", "x", status)
     vvd(y,  0.4020580099454020310e-4, 1e-15, "xys06a", "y", status)
-    vvd(s, -0.1220032294164579896e-7, 1e-18, "xys06a", "s", status)
+    vvd(s, -0.1220032294164579896e-7, 0.0, "xys06a", "s", status)
 
 
 @pytest.mark.xfail(np.__version__ < '1.24', reason='numpy < 1.24 do not support no-input ufuncs') 
```
the resulting traceback is
```
_____________________________________________ test_xys06a _____________________________________________

    def test_xys06a():
        x, y, s = erfa_ufunc.xys06a(2400000.5, 53736.0)
        vvd(x,  0.5791308482835292617e-3, 1e-14, "xys06a", "x", status)
        vvd(y,  0.4020580099454020310e-4, 1e-15, "xys06a", "y", status)
>       vvd(s, -0.1220032294164579896e-7, 0.0, "xys06a", "s", status)

erfa/tests/test_ufunc.py:3732: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

val = np.float64(-1.22003229416848e-08), valok = -1.22003229416458e-08, dval = 0.0, func = 'xys06a'
test = 's', _ = array(0)

    def vvd(val, valok, dval, func, test, _):
        """Validate a double result."""
        a = val - valok
>       assert a == 0.0 or abs(a) <= abs(dval), (
            f"{func} failed: {test} want {valok:.20g} got {val:.20g} "
            f"(1/{abs(valok / a):.3g})")
E       AssertionError: xys06a failed: s want -1.2200322941645799674e-08 got -1.2200322941684799586e-08 (1/3.13e+11)
E       assert (np.float64(-3.899991152065015e-20) == 0.0 or np.float64(3.899991152065015e-20) <= 0.0)
E        +  where np.float64(3.899991152065015e-20) = abs(np.float64(-3.899991152065015e-20))
E        +  and   0.0 = abs(0.0)

erfa/tests/test_ufunc.py:41: AssertionError
```
but if an analogous change is made to the file generated by this PR
```diff
@@ -3713,7 +3713,7 @@ def test_xys06a():
     x, y, s = erfa_ufunc.xys06a(2400000.5, 53736.0)
     assert x == pytest.approx(0.5791308482835292617e-3, abs=1e-14)
     assert y == pytest.approx(0.4020580099454020310e-4, abs=1e-15)
-    assert s == pytest.approx(-0.1220032294164579896e-7, abs=1e-18)
+    assert s == pytest.approx(-0.1220032294164579896e-7, abs=0.0)
 
 
 @pytest.mark.xfail(np.__version__ < '1.24', reason='numpy < 1.24 do not support no-input ufuncs')
```
then the traceback is much shorter and much clearer:
```
_____________________________________________ test_xys06a _____________________________________________

    def test_xys06a():
        x, y, s = erfa_ufunc.xys06a(2400000.5, 53736.0)
        assert x == pytest.approx(0.5791308482835292617e-3, abs=1e-14)
        assert y == pytest.approx(0.4020580099454020310e-4, abs=1e-15)
>       assert s == pytest.approx(-0.1220032294164579896e-7, abs=0.0)
E       assert np.float64(-1...229416848e-08) == -1.2200322941...e-08 ± 0.0e+00
E         
E         comparison failed
E         Obtained: -1.22003229416848e-08
E         Expected: -1.22003229416458e-08 ± 0.0e+00

erfa/tests/test_ufunc.py:3716: AssertionError
```