### PR TITLE
Speed up functions that can emit a warning or raise an error

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -64,7 +64,7 @@ STATUS_CODES_REMAP = {
 
 
 def check_errwarn(statcodes, func_name):
-    if not np.any(statcodes):
+    if not statcodes.any():
         return
     statcodes = np.atleast_1d(statcodes)
     # Remap any errors into warnings in the STATUS_CODES_REMAP dict.


### PR DESCRIPTION
This PR speeds up all the functions in `core.py` for which the corresponding ufunc returns a status code that is checked by `check_errwarn()`. The speedup is easily noticeable for scalars and small arrays. For example, on current `main`
```
$ cat timing_setup.py 
import numpy as np

from erfa import cal2jd


scalar_year = 2026
scalar_month = 6
scalar_day = 20

arr_year = np.full((1000,), 2026)
arr_month = np.full((1000,), 6)
arr_day = np.full((1000,), 20)
$ ipython -i timing_setup.py 
Python 3.11.12 (main, May 17 2025, 13:48:36) [Clang 20.1.4 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.13.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can find how to type a LaTeX symbol by back-completing it, eg `\θ<tab>` will expand to `\theta`.

In [1]: %timeit cal2jd(scalar_year, scalar_month, scalar_day)
4.21 μs ± 19.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit cal2jd(arr_year, arr_month, arr_day)
8.79 μs ± 28.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
but with this PR
```
In [1]: %timeit cal2jd(scalar_year, scalar_month, scalar_day)
2.88 μs ± 1.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit cal2jd(arr_year, arr_month, arr_day)
7.74 μs ± 15.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```