### PR TITLE
Require `numpy` >= 1.24

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
 ====================
 - Let multi-output functions now return a ``namedtuple`` so that
   the various results can be accessed by attribute. [gh-176]
+- ``pyerfa`` now requires Python 3.10 or later. [gh-185]
 - The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
   unavoidable ``KeyError``. [gh-234]
 - ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an
-  ``ErfaError`` or ``ErfaWarning`` if all its inputs are scalars.
+  ``ErfaError`` or ``ErfaWarning`` if all its inputs are scalars. [gh-235]
+- ``pyerfa`` now requires ``numpy`` 1.24 or later. [gh-250]
 
 2.0.1.6 (2025-01-27)
 ====================

--- a/erfa/tests/test_ufunc.py.templ
+++ b/erfa/tests/test_ufunc.py.templ
@@ -32,9 +32,6 @@ if not erfa.__version__.startswith(erfa.version.erfa_version):
 {%- for test in test_funcs %}
 
 
-{% if test.xfail() -%}
-@pytest.mark.xfail({{ test.xfail() }})
-{% endif -%}
 def test_{{ test.name }}():
     {%- for line in test.to_python() %}
     {{ line }}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -373,18 +373,6 @@ class TestFunction:
             ninout=len(func.args_by_inout("inout")),
         )
 
-    def xfail(self):
-        """Whether the python test produced for this function will fail when the xfail condition is verified.
-
-        Right now this will be true for functions without inputs such
-        as eraIr with numpy < 1.24.
-        """
-        return (
-            "np.__version__ < '1.24', reason='numpy < 1.24 do not support no-input ufuncs'"
-            if self.nin + self.ninout == 0 and self.name != "zpv"
-            else None
-        )
-
     def pre_process_lines(self):
         """Basic pre-processing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 urls = {Homepage = "https://github.com/liberfa/pyerfa"}
 requires-python = ">=3.10"
-dependencies = ["numpy>=1.21.3"]
+dependencies = ["numpy>=1.24"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    oldestdeps: numpy==1.21.*
+    oldestdeps: numpy==1.24.*
     devdeps: numpy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
With older `numpy` versions ufuncs without parameters do not work. There are several such functions in `pyerfa`, so those `numpy` versions are not being properly supported anyways. [SPEC 0](https://scientific-python.org/specs/spec-0000/) allows dropping support for `numpy` < 2, so we will still be very generous with our requirements.