### PR TITLE
Start enforcing the Ruff RUF rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ author = 'The PyERFA Developers'
 build_date = datetime.utcfromtimestamp(
     int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
 )
-copyright = f"2011–{build_date.year}, {author}"
+copyright = f"2011-{build_date.year}, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -123,7 +123,7 @@ html_favicon = None
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
 
-# A dictionary of values to pass into the template engine’s context for all pages.
+# A dictionary of values to pass into the template engine's context for all pages.
 html_context = {
     'to_be_indexed': ['stable', 'latest']
 }

--- a/erfa/tests/test_erfa.py
+++ b/erfa/tests/test_erfa.py
@@ -60,40 +60,43 @@ def test_version_with_embedded_liberfa():
     assert erfa.__version__.startswith(erfa.version.erfa_version)
 
 
-def test_erfa_wrapper():
-    """
-    Runs a set of tests that mostly make sure vectorization is
-    working as expected
-    """
+@pytest.mark.parametrize(
+    ("ra", "dec", "jd", "shape"),
+    [
+        pytest.param(0.0, 0.0, 2456855.5, (), id="scalar"),
+        pytest.param(
+            0.0, 0.0, np.linspace(2456855.5, 2456856.5, 5), (5,), id="simple array"
+        ),
+        pytest.param(
+            np.linspace(0.0, np.pi * 2.0, 5)[:, None, None],
+            np.linspace(-np.pi / 2.0, np.pi / 2.0, 4)[:, None],
+            np.linspace(2456855.5, 2456856.5, 3),
+            (5, 4, 3),
+            id="broadcasting",
+        ),
+    ],
+)
+def test_atco13_shape(ra, dec, jd, shape):
+    assert (
+        erfa.atco13(
+            ra, dec, 0, 0, 0, 0, jd, 0, 0, 0, np.pi / 4, 0, 0, 0, 1014, 0, 0, 0.5
+        ).aob.shape
+        == shape
+    )
 
-    jd = np.linspace(2456855.5, 2456855.5+1.0/24.0/60.0, 60*2+1)
-    ra = np.linspace(0.0, np.pi*2.0, 5)
-    dec = np.linspace(-np.pi/2.0, np.pi/2.0, 4)
 
-    aob, zob, hob, dob, rob, eo = erfa.atco13(
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd,
-        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
-    assert aob.shape == (121,)
-
-    aob, zob, hob, dob, rob, eo = erfa.atco13(
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, jd[0],
-        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
-    assert aob.shape == ()
-
-    aob, zob, hob, dob, rob, eo = erfa.atco13(
-        ra[:, None, None], dec[None, :, None], 0.0, 0.0, 0.0, 0.0, jd[None, None, :],
-        0.0, 0.0, 0.0, np.pi/4.0, 0.0, 0.0, 0.0, 1014.0, 0.0, 0.0, 0.5)
-    (aob.shape) == (5, 4, 121)
-
-    iy, im, id, ihmsf = erfa.d2dtf("UTC", 3, jd, 0.0)
-    assert iy.shape == (121,)
-    assert ihmsf.shape == (121,)
-    assert ihmsf.dtype == erfa.dt_hmsf
-
-    iy, im, id, ihmsf = erfa.d2dtf("UTC", 3, jd[0], 0.0)
-    assert iy.shape == ()
-    assert ihmsf.shape == ()
-    assert ihmsf.dtype == erfa.dt_hmsf
+@pytest.mark.parametrize(
+    ("jd", "shape"),
+    [
+        pytest.param(2456855.5, (), id="scalar"),
+        pytest.param([2456855.5, 2456855.75, 2456856.25], (3,), id="array"),
+    ],
+)
+def test_d2dtf_shape(jd, shape):
+    result = erfa.d2dtf("UTC", 3, jd, 0.0)
+    assert result.iy.shape == shape
+    assert result.ihmsf.shape == shape
+    assert result.ihmsf.dtype == erfa.dt_hmsf
 
 
 def test_angle_ops():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ extend-select = [
     "PT",
     "PTH",
     "RET",
+    "RUF",
     "S101",
     "SIM",
     "UP",


### PR DESCRIPTION
I am configuring Ruff to enforce its [RUF rules](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf). There were two kinds of RUF violations that had to be fixed.

`docs/conf.py` contained non-ASCII characters that are visually indistinguishable or almost indistinguishable from ASCII characters. Personally I am not opposed to using non-ASCII characters when they improve readability (e.g. writing `α` instead of `alpha`), but visually indistinguishable characters cannot possibly do that.

In `erfa/tests/test_erfa.py` Ruff pointed out several unused unpacked variables. If a `pyerfa` Python wrapper function returns a `tuple` it will have named attributes, so if only one or two values are needed then unpacking the tuple does not improve readability. I've rewritten the test in question as two separate parametrized tests.