### PR TITLE
Simplify classifying ERFA function arguments in `Argument.inout_state`

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -30,11 +30,14 @@ class FunctionDoc:
         get_arg_doc_list = functools.partial(
             self._get_arg_doc_list, n_spaces=4 if pyname in ("ab", "refco") else 5
         )
-        inout = get_arg_doc_list("Given and returned:\n(.+?)\n\n")
-        self.input: Final = get_arg_doc_list("Given.*?\n(.+?)\n\n") | inout
-        self.output: Final = inout | get_arg_doc_list("Returned.*?\n(.+?)\n\n")
+        self.input: Final = get_arg_doc_list("Given.*?\n(.+?)\n\n")
+        self.inout: Final = get_arg_doc_list("Given and returned:\n(.+?)\n\n")
+        self.output: Final = get_arg_doc_list("Returned.*?\n(.+?)\n\n")
+        if pyname in ("aper", "aper13"):
+            self.input.remove("astrom")
+            self.inout.add(self.output.pop())
 
-    def _get_arg_doc_list(self, regex: str, n_spaces: int) -> frozenset[str]:
+    def _get_arg_doc_list(self, regex: str, n_spaces: int) -> set[str]:
         """Parse input/output doc section lines, getting arguments from them.
 
         Also remove the nb argument in front of eraLDBODY, as we infer nb from
@@ -42,7 +45,7 @@ class FunctionDoc:
         """
         result = re.search(regex, self.doc, re.DOTALL)
         if result is None:
-            return frozenset()
+            return set()
         doc_list = []
         for name, c_type in re.findall(
             rf"^{n_spaces * ' '}([\w\*,]+) +([\w\[\]\*]+) +.+?",
@@ -56,7 +59,7 @@ class FunctionDoc:
                 # to determine this from the array itself.
                 doc_list.pop()
             doc_list.extend(name.replace("*", "").split(","))
-        return frozenset(doc_list)
+        return set(doc_list)
 
     @property
     def title(self):
@@ -117,12 +120,13 @@ class Argument(Variable):
 
     @functools.cached_property
     def inout_state(self) -> str:
-        inout_state = ""
         if self.name in self.doc.input:
-            inout_state = "in"
+            return "in"
+        if self.name in self.doc.inout:
+            return "inout"
         if self.name in self.doc.output:
-            inout_state = "inout" if inout_state == "in" else "out"
-        return inout_state
+            return "out"
+        return ""
 
     @property
     def name_for_call(self) -> str:


### PR DESCRIPTION
Some of the ERFA C function arguments are only read from (`pyerfa` calls these "in" arguments), others are only written to ("out" arguments) and some are both read from and written to ("inout" arguments). Because it is impossible to tell how an argument is used from a C function's declaration, the `FunctionDoc` class in `erfa_generator` has to parse the doc comments to perform the classification.

In two ERFA functions an argument is meant to be a struct with some fields that are only read from and others that are only written to. For `pyerfa` it is an "inout" argument, but the ERFA doc comments list it as both an "in" and an "out" argument, not as an "inout" argument. `FunctionDoc` has so far dealt with this by merging "inout" arguments with both "in" and "out" arguments and the `Argument.inout_state` property has to disentangle them. In this PR `FunctionDoc` keeps all three argument categories separate and the two unusual ERFA functions are handled explicitly. Most importantly their names are written down, which makes it much simpler to look up why there is a special case for them.