### PR TITLE
Simplify extracting summaries from ERFA function doc comments

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -129,7 +129,7 @@ STATUS_CODES['{{ func.pyname }}'] = {{ stat.to_python() }}
 
 def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }}):
     """
-    {{ func.doc.title }}
+    {{ func.doc.first_sentence | indent(2)}}
     {%- if func.args_by_inout('in|inout') %}
 
     Parameters

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -21,6 +21,7 @@ DEFAULT_TEMPLATE_LOC = Path(__file__).with_name("erfa")
 
 class FunctionDoc:
     def __init__(self, doc: str, pyname: str) -> None:
+        self.pyname: Final = pyname
         if pyname == "ldn":
             doc = doc.removeprefix("+")
         elif pyname == "aticqn":
@@ -62,22 +63,12 @@ class FunctionDoc:
         return set(doc_list)
 
     @property
-    def title(self):
-        # Used for the docstring title.
-        lines = [line.strip() for line in self.doc.split('\n')[4:10]]
-        # Always include the first line, then stop at either an empty
-        # line or at the end of a sentence.
-        description = lines[:1]
-        for line in lines[1:]:
-            if line == '':
-                break
-            if '. ' in line:
-                line = line[:line.index('. ')+1]
-            description.append(line)
-            if line.endswith('.'):
-                break
-
-        return '\n    '.join(description)
+    def first_sentence(self) -> str:
+        if m := re.search(r"[- ]+\n\n  (.+?\.)\s", self.doc, re.DOTALL):
+            return m.group(1)
+        raise RuntimeError(
+            f"cannot find the first sentence of {self.pyname} doc comment"
+        )
 
 
 class Variable:


### PR DESCRIPTION
On current `main` branch `erfa_generator` extracts the first and sometimes also the second sentence from an ERFA function doc comment and inserts it into the beginning of the docstring of the corresponding Python function as a summary. This PR always extracts only the first sentence. In practice this only changes the docstrings of `atco13()`, `atio13()`, `atoc13()` `atoi13()`, which all have the same second sentence, but this can't be a problem because the `eraApio13` doc comment also contains that sentence and current `main` is already not including it in the `apio13()` docstring summary. In any case the full contents of the ERFA doc comments are always added to the Notes sections of the docstrings, so nothing is really being hidden from interested users.