### PR TITLE
Move result tuple implementation from `core.py` template to `erfa_generator`

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -120,10 +120,10 @@ STATUS_CODES['{{ func.pyname }}'] = {{ stat.to_python() }}
  # For ufuncs with more than one output, define a namedtuple so one
  # can access the outputs by name.
  #}
-{%- if func.args_by_inout('inout|out|ret')|length > 1 %}
+{%- if func.result_tuple %}
 
 
-{{ func.pyname|capitalize }}Result = namedtuple('{{ func.pyname|capitalize }}Result', "{{ func.args_by_inout('inout|out|ret')|map(attribute='name')|join(', ') }}")
+{{ func.result_tuple.define() }}
 {%- endif %}
 
 
@@ -141,8 +141,8 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
     Returns
     -------
-    {%- if func.args_by_inout('inout|out|ret')|length > 1 %}
-    A ``{{ func.pyname|capitalize }}Result`` namedtuple with the following attributes:
+    {%- if func.result_tuple %}
+    A ``{{ func.result_tuple.name }}`` namedtuple with the following attributes:
     {%- endif %}
     {%- for arg in func.args_by_inout('inout|out|ret') %}
     {{ arg.name }} : {{ arg.ctype }} array
@@ -181,10 +181,10 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
     {#-
      # Return the output arguments (including the inplace ones)
      #}
-    {%- if func.args_by_inout('inout|out|ret')|length == 1 %}
-    return {{ func.args_by_inout('inout|out|ret')[0].name }}
+    {%- if func.result_tuple %}
+    return {{ func.result_tuple.create() }}
     {%- else %}
-    return {{ func.pyname|capitalize }}Result({{ func.args_by_inout('inout|out|ret')|map(attribute='name')|join(', ') }})
+    return {{ func.args_by_inout('inout|out|ret')[0].name }}
     {%- endif %}
 
 {%- endfor %}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -12,6 +12,7 @@ or dtypes for those structs.  They should be added manually in the template file
 
 import functools
 import re
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Final, final
 
@@ -233,6 +234,18 @@ class Return(Variable):
         super().__init__(ctype)
 
 
+class ResultTuple:
+    def __init__(self, func_name: str, args: Iterable[Argument | Return]) -> None:
+        self.name: Final = f"{func_name.capitalize()}Result"
+        self.arg_names: Final = ", ".join(arg.name for arg in args)
+
+    def create(self) -> str:
+        return f"{self.name}({self.arg_names})"
+
+    def define(self) -> str:
+        return f'{self.name} = namedtuple({self.name!r}, "{self.arg_names}")'
+
+
 class Function:
     """
     A class representing a C function.
@@ -266,6 +279,12 @@ class Function:
                 if ret == "int" and self.pyname not in ("tpors", "tporv")
                 else Return(ret)
             )
+
+        self.result_tuple: Final = (
+            ResultTuple(self.pyname, py_return)
+            if len(py_return := self.args_by_inout("inout|out|ret")) > 1
+            else None
+        )
 
     def args_by_inout(self, inout_filter):
         """


### PR DESCRIPTION
Since #176 if a Python wrapper returns a tuple then its elements can be accessed as named attributes. So far the implementation of that feature has been in the `core.py` template, but this PR moves a lot of the implementation to the new `ResultTuple` class in `erfa_generator`, where it can be simplified.

This PR makes no changes to the `core.py` file `erfa_generator` creates.