### PR TITLE
Avoid needless local variables in Python wrappers

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -158,34 +158,7 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
 {{ func.doc.doc | indent(6, true) }}
     """
-
-    {#-
-     # Call the ufunc. Note that we pass inout twice, once as input
-     # and once as output, so that changes are done in-place
-     #}
-    {{ func.python_call }}
-    {#-
-     # Check whether any warnings or errors occurred.
-     #}
-    {%- for arg in func.args_by_inout('stat') %}
-    check_errwarn({{ arg.name }}, '{{ func.pyname }}')
-    {%- endfor %}
-    {#-
-     # Any string outputs will be in structs; view them as their base type.
-     #}
-    {%- for arg in func.args_by_inout('out') -%}
-    {%- if arg.ctype == "char" %}
-    {{ arg.name }} = {{ arg.name }}.view(dt_bytes1)
-    {%- endif %}
-    {%- endfor %}
-    {#-
-     # Return the output arguments (including the inplace ones)
-     #}
-    {%- if func.result_tuple %}
-    return {{ func.result_tuple.create() }}
-    {%- else %}
-    return {{ func.args_by_inout('inout|out|ret')[0].name }}
-    {%- endif %}
+    {{ func.generate_python_body() | indent(4) }}
 
 {%- endfor %}
 {# done! (note: this comment also ensures final new line!) #}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -351,6 +351,32 @@ class Function:
         return ('(' + result[:split_point] + '\n    '
                 + result[split_point:].replace(' =', ') ='))
 
+    def generate_python_body(self) -> str:
+        lines = [self.python_call]
+        if status_code := self.args_by_inout("stat"):
+            lines.append(f"check_errwarn({status_code[0].name}, {self.pyname!r})")
+        lines.extend(
+            f"{arg.name} = {arg.name}.view(dt_bytes1)"
+            for arg in self.args_by_inout("out")
+            if arg.ctype == "char"
+        )
+        if len(lines) == 1:
+            arg_names = [arg.name for arg in self.args_by_inout("in|inout")]
+            ufunc_call = f"ufunc.{self.pyname}({', '.join(arg_names)})"
+            ret_val = (
+                ufunc_call
+                if self.result_tuple is None
+                else f"{self.result_tuple.name}(*{ufunc_call})"
+            )
+            return f"return {ret_val}"
+        ret_val = (
+            self.args_by_inout("inout|out|ret")[0].name
+            if self.result_tuple is None
+            else self.result_tuple.create()
+        )
+        lines.append(f"return {ret_val}")
+        return "\n".join(lines)
+
 
 class Constant:
 


### PR DESCRIPTION
The Python wrappers that can simply return the corresponding ufunc's return value no longer store the ufunc's output in local variables, which makes them slightly faster. For example, on current `main`
```
$ ipython -i -c 'from erfa import epb2jd, zp'
Python 3.11.12 (main, May 17 2025, 13:48:36) [Clang 20.1.4 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.13.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Put a ';' at the end of a line to suppress the printing of output.

In [1]: %timeit epb2jd(1957.3)
829 ns ± 1.19 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit zp()
421 ns ± 0.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
but with this PR
```
In [1]: %timeit epb2jd(1957.3)
810 ns ± 1.59 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit zp()
418 ns ± 0.631 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
This does not affect any wrappers that have to check the status code the ufunc returns or that take new views of any of the returned arrays.