### PR TITLE
Format `erfa/core.py` closer to Black style

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -32,11 +32,15 @@ import numpy as np
 from . import ufunc
 
 __all__ = [
-    'ErfaError', 'ErfaWarning',
-    {{ funcs | map(attribute='pyname') | surround("'","'")
-       | join(", ") | wordwrap(wrapstring='\n    ') }},
-    {{ constants | map(attribute='name') | surround("'","'")
-       | join(", ") | wordwrap(wrapstring='\n    ') }}]
+    {%- for const in constants %}
+    "{{ const.name }}",
+    {%- endfor %}
+    "ErfaError",
+    "ErfaWarning",
+    {%- for func in funcs %}
+    "{{ func.pyname }}",
+    {%- endfor %}
+]
 
 
 class ErfaError(ValueError):
@@ -58,9 +62,7 @@ STATUS_CODES = {}  # populated below before each function that returns an int
 
 # This is a hard-coded list of status codes that need to be remapped,
 # such as to turn errors into warnings.
-STATUS_CODES_REMAP = {
-    'cal2jd': {-3: 3}
-}
+STATUS_CODES_REMAP = {"cal2jd": {-3: 3}}
 
 
 def check_errwarn(statcodes, func_name):
@@ -79,25 +81,29 @@ def check_errwarn(statcodes, func_name):
     if erridx[0].size > 0:
         # Errors present - only report the errors.
         errcodes, counts = np.unique(statcodes[erridx], return_counts=True)
-        elsemsg = STATUS_CODES[func_name].get('else', None)
-        msgs = [STATUS_CODES[func_name].get(e, elsemsg or f'Return code {e}')
-                for e in errcodes]
-        emsg = ', '.join([f'{c} of "{msg}"' for c, msg in zip(counts, msgs)])
+        elsemsg = STATUS_CODES[func_name].get("else", None)
+        msgs = [
+            STATUS_CODES[func_name].get(e, elsemsg or f"Return code {e}")
+            for e in errcodes
+        ]
+        emsg = ", ".join([f'{c} of "{msg}"' for c, msg in zip(counts, msgs)])
         raise ErfaError(f'ERFA function "{func_name}" yielded {emsg}')
 
     warnidx = (statcodes > 0).nonzero()
     if warnidx[0].size > 0:
         warncodes, counts = np.unique(statcodes[warnidx], return_counts=True)
-        elsemsg = STATUS_CODES[func_name].get('else', None)
-        msgs = [STATUS_CODES[func_name].get(w, elsemsg or f'Return code {w}')
-                for w in warncodes]
-        wmsg = ', '.join([f'{c} of "{msg}"' for c, msg in zip(counts, msgs)])
+        elsemsg = STATUS_CODES[func_name].get("else", None)
+        msgs = [
+            STATUS_CODES[func_name].get(w, elsemsg or f"Return code {w}")
+            for w in warncodes
+        ]
+        wmsg = ", ".join([f'{c} of "{msg}"' for c, msg in zip(counts, msgs)])
         warn(f'ERFA function "{func_name}" yielded {wmsg}', ErfaWarning)
 
 
 # <------------------------structured dtype conversion------------------------>
 
-dt_bytes1 = np.dtype('S1')
+dt_bytes1 = np.dtype("S1")
 
 # <--------------------------Actual ERFA-wrapping code------------------------>
 
@@ -114,7 +120,7 @@ dt_bytes1 = np.dtype('S1')
 {%- for stat in func.args_by_inout('stat') %}
 
 
-STATUS_CODES['{{ func.pyname }}'] = {{ stat.to_python() }}
+STATUS_CODES["{{ func.pyname }}"] = {{ stat.to_python() }}
 {%- endfor %}
 {#-
  # For ufuncs with more than one output, define a namedtuple so one

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -222,7 +222,7 @@ class StatusCode(Variable):
 
     def to_python(self) -> str:
         return "\n".join(
-            ["{", *[f"    {k!r}: {v!r}," for k, v in self._statuscodes.items()], "}"]
+            ["{", *[f'    {k!r}: "{v}",' for k, v in self._statuscodes.items()], "}"]
         )
 
 
@@ -242,7 +242,7 @@ class ResultTuple:
         return f"{self.name}({self.arg_names})"
 
     def define(self) -> str:
-        return f'{self.name} = namedtuple({self.name!r}, "{self.arg_names}")'
+        return f'{self.name} = namedtuple("{self.name}", "{self.arg_names}")'
 
 
 class Function:
@@ -344,7 +344,7 @@ class Function:
             )
         ]
         if status_code := self.args_by_inout("stat"):
-            lines.append(f"check_errwarn({status_code[0].name}, {self.pyname!r})")
+            lines.append(f'check_errwarn({status_code[0].name}, "{self.pyname}")')
         lines.extend(
             f"{arg.name} = {arg.name}.view(dt_bytes1)"
             for arg in self.args_by_inout("out")
@@ -550,7 +550,9 @@ def main(srcdir: Path, templateloc: Path) -> None:
         constants.extend(
             Constant(name, value, doc)
             for name, value in re.findall(
-                r"#define (ERFA_\w+?) (.+?)$", chunk, flags=re.DOTALL | re.MULTILINE
+                r"#define (ERFA_\w+?) \(?(.+?)\)?$",
+                chunk,
+                flags=re.DOTALL | re.MULTILINE,
             )
         )
 


### PR DESCRIPTION
The generated `erfa/core.py` file now follows [Black style](https://black.readthedocs.io/en/stable/the_black_code_style/index.html) (also [used by the Ruff formatter](https://docs.astral.sh/ruff/formatter/#style-guide)) as much as possible without having to introduce formatting-specific conditional branching in `erfa_generator` or the `core.py` template. String literals now prefer using `"` instead of `'`, definitions of constants no longer have unnecessary parentheses and the definition of `erfa.core.__all__` now contains one entry per line. A handful of statements in the template were adjusted to account for the 88 character line length limit.

I don't think generating an `erfa/core.py` that follows the Black style even closer is worth the effort, but in #260 the option of formatting the file by having `erfa_generator` (or maybe `setup.py`) call Black or the Ruff formatter was discussed. Now that we can see how much formatting would change the file, we can decide if automatically invoking the formatter is worthwhile.

<details>
  <summary>The full output of `ruff format --diff erfa/core.py`</summary>

```diff
--- erfa/core.py
+++ erfa/core.py
@@ -421,9 +421,9 @@
 """Astronomical unit (m, IAU 2012)"""
 CMPS = 299792458.0
 """Speed of light (m/s)"""
-AULT = DAU/CMPS
+AULT = DAU / CMPS
 """Light time for 1 au (s)"""
-DC = DAYSEC/AULT
+DC = DAYSEC / AULT
 """Speed of light (au per day)"""
 ELG = 6.969290134e-10
 """L_G = 1 - d(TT)/d(TCG)"""
@@ -1557,7 +1557,9 @@
     return Apci13Result(*ufunc.apci13(date1, date2))
 
 
-def apco(date1, date2, ebpv, ehp, x, y, s, theta, elong, phi, hm, xp, yp, sp, refa, refb):
+def apco(
+    date1, date2, ebpv, ehp, x, y, s, theta, elong, phi, hm, xp, yp, sp, refa, refb
+):
     """
     For a terrestrial observer, prepare star-independent astrometry
     parameters for transformations between ICRS and observed
@@ -1747,7 +1749,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    return ufunc.apco(date1, date2, ebpv, ehp, x, y, s, theta, elong, phi, hm, xp, yp, sp, refa, refb)
+    return ufunc.apco(
+        date1, date2, ebpv, ehp, x, y, s, theta, elong, phi, hm, xp, yp, sp, refa, refb
+    )
 
 
 STATUS_CODES["apco13"] = {
@@ -1965,7 +1969,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    astrom, eo, c_retval = ufunc.apco13(utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    astrom, eo, c_retval = ufunc.apco13(
+        utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+    )
     check_errwarn(c_retval, "apco13")
     return Apco13Result(astrom, eo)
 
@@ -2852,7 +2858,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    astrom, c_retval = ufunc.apio13(utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    astrom, c_retval = ufunc.apio13(
+        utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+    )
     check_errwarn(c_retval, "apio13")
     return astrom
 
@@ -3493,7 +3501,9 @@
 Atco13Result = namedtuple("Atco13Result", "aob, zob, hob, dob, rob, eo")
 
 
-def atco13(rc, dc, pr, pd, px, rv, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl):
+def atco13(
+    rc, dc, pr, pd, px, rv, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+):
     """
     ICRS RA,Dec to observed place.
 
@@ -3681,7 +3691,26 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    aob, zob, hob, dob, rob, eo, c_retval = ufunc.atco13(rc, dc, pr, pd, px, rv, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    aob, zob, hob, dob, rob, eo, c_retval = ufunc.atco13(
+        rc,
+        dc,
+        pr,
+        pd,
+        px,
+        rv,
+        utc1,
+        utc2,
+        dut1,
+        elong,
+        phi,
+        hm,
+        xp,
+        yp,
+        phpa,
+        tc,
+        rh,
+        wl,
+    )
     check_errwarn(c_retval, "atco13")
     return Atco13Result(aob, zob, hob, dob, rob, eo)
 
@@ -4183,7 +4212,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    aob, zob, hob, dob, rob, c_retval = ufunc.atio13(ri, di, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    aob, zob, hob, dob, rob, c_retval = ufunc.atio13(
+        ri, di, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+    )
     check_errwarn(c_retval, "atio13")
     return Atio13Result(aob, zob, hob, dob, rob)
 
@@ -4499,7 +4530,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    rc, dc, c_retval = ufunc.atoc13(type, ob1, ob2, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    rc, dc, c_retval = ufunc.atoc13(
+        type, ob1, ob2, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+    )
     check_errwarn(c_retval, "atoc13")
     return Atoc13Result(rc, dc)
 
@@ -4687,7 +4720,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    ri, di, c_retval = ufunc.atoi13(type, ob1, ob2, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl)
+    ri, di, c_retval = ufunc.atoi13(
+        type, ob1, ob2, utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl
+    )
     check_errwarn(c_retval, "atoi13")
     return Atoi13Result(ri, di)
 
@@ -5145,7 +5180,7 @@
     1: "distance overridden (Note 6)",
     2: "excessive velocity (Note 7)",
     4: "solution didn't converge (Note 8)",
-    'else': "binary logical OR of the above warnings",
+    "else": "binary logical OR of the above warnings",
 }
 
 
@@ -5289,7 +5324,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    ra2, dec2, pmr2, pmd2, px2, rv2, c_retval = ufunc.pmsafe(ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b)
+    ra2, dec2, pmr2, pmd2, px2, rv2, c_retval = ufunc.pmsafe(
+        ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b
+    )
     check_errwarn(c_retval, "pmsafe")
     return PmsafeResult(ra2, dec2, pmr2, pmd2, px2, rv2)
 
@@ -9902,7 +9939,10 @@
     return ufunc.obl80(date1, date2)
 
 
-P06eResult = namedtuple("P06eResult", "eps0, psia, oma, bpa, bqa, pia, bpia, epsa, chia, za, zetaa, thetaa, pa, gam, phi, psi")
+P06eResult = namedtuple(
+    "P06eResult",
+    "eps0, psia, oma, bpa, bqa, pia, bpia, epsa, chia, za, zetaa, thetaa, pa, gam, phi, psi",
+)
 
 
 def p06e(date1, date2):
@@ -14129,7 +14169,7 @@
     1: "distance overridden (Note 6)",
     2: "excessive speed (Note 7)",
     4: "solution didn't converge (Note 8)",
-    'else': "binary logical OR of the above",
+    "else": "binary logical OR of the above",
 }
 
 
@@ -15191,7 +15231,7 @@
     1: "distance overridden (Note 6)",
     2: "excessive velocity (Note 7)",
     4: "solution didn't converge (Note 8)",
-    'else': "binary logical OR of the above warnings",
+    "else": "binary logical OR of the above warnings",
 }
 
 
@@ -15335,7 +15375,9 @@
         Derived, with permission, from the SOFA library.  See notes at end of file.
 
     """
-    ra2, dec2, pmr2, pmd2, px2, rv2, c_retval = ufunc.starpm(ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b)
+    ra2, dec2, pmr2, pmd2, px2, rv2, c_retval = ufunc.starpm(
+        ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b
+    )
     check_errwarn(c_retval, "starpm")
     return StarpmResult(ra2, dec2, pmr2, pmd2, px2, rv2)
 

1 file would be reformatted
```
</details>