### PR TITLE
Implement the `Function.c_retval` attribute

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -117,11 +117,11 @@ dt_bytes1 = np.dtype("S1")
 {#-
  # Define the status codes that this function returns.
  #}
-{%- for stat in func.args_by_inout('stat') %}
+{%- if func.c_retval.inout_state == "stat" %}
 
 
-STATUS_CODES["{{ func.pyname }}"] = {{ stat.to_python() }}
-{%- endfor %}
+STATUS_CODES["{{ func.pyname }}"] = {{ func.c_retval.to_python() }}
+{%- endif %}
 {#-
  # For ufuncs with more than one output, define a namedtuple so one
  # can access the outputs by name.

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -200,9 +200,9 @@ static void ufunc_loop_{{ func.pyname }}(
    {%- endif %}
   {%- endfor %}
   {#- /* variables to hold status and return values */ #}
-  {%- for arg in func.args_by_inout('stat|ret') %}
-    {{ arg.ctype }} _{{ arg.name }};
-  {%- endfor %}
+  {%- if func.c_retval %}
+    {{ func.c_retval.ctype }} _{{ func.c_retval.name }};
+  {%- endif %}
   {#- /*
        * For GENERALIZED UFUNCS - inner loop steps, needs for copying.
        */ #}
@@ -321,18 +321,14 @@ static void ufunc_loop_{{ func.pyname }}(
       {#- /*
            * call the actual erfa function
            */ #}
-        {{ func.args_by_inout('ret|stat') |
-                    map(attribute='name') |
-                    surround('_', ' = ') |
-                    join
-        }}{{ func.name
+        {% if func.c_retval %}_{{ func.c_retval.name }} = {% endif %}{{ func.name
         }}({{ func.args_by_inout('in|inout|out') |
                     map(attribute='name_for_call') |
                     join(', ') }});
       {#- /* store any return values */ #}
-      {%- for arg in func.args_by_inout('ret|stat') %}
-        *(({{ arg.ctype }} *){{ arg.name }}) = _{{ arg.name }};
-      {%- endfor %}
+      {%- if func.c_retval %}
+        *(({{ func.c_retval.ctype }} *){{ func.c_retval.name }}) = _{{ func.c_retval.name }};
+      {%- endif %}
       {%- if func.signature %}
        {#- /* for generalized ufunc, copy output from buffer if needed */ #}
        {%- for arg in func.args_by_inout('inout|out') %}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -257,6 +257,8 @@ class Function:
         Directory with the file containing the function implementation.
     """
 
+    c_retval: Return | StatusCode | None = None
+
     def __init__(self, name: str, source_path: Path) -> None:
         self.name: Final = name
         self.pyname: Final = name.removeprefix("era").lower()
@@ -273,11 +275,12 @@ class Function:
             Argument(arg, self.doc) for arg in re.findall("[^,]+", search.group(2))
         ]
         if (ret := search.group(1)) != "void":
-            self.args.append(
+            self.c_retval = (
                 StatusCode(ret, self.doc, name)
                 if ret == "int" and self.pyname not in ("tpors", "tporv")
                 else Return(ret)
             )
+            self.args.append(self.c_retval)
 
         self.result_tuple: Final = (
             ResultTuple(self.pyname, py_return)
@@ -343,8 +346,8 @@ class Function:
                 out_args=[arg.name for arg in self.args_by_inout("inout|out|stat|ret")],
             )
         ]
-        if status_code := self.args_by_inout("stat"):
-            lines.append(f'check_errwarn({status_code[0].name}, "{self.pyname}")')
+        if isinstance(self.c_retval, StatusCode):
+            lines.append(f'check_errwarn({self.c_retval.name}, "{self.pyname}")')
         lines.extend(
             f"{arg.name} = {arg.name}.view(dt_bytes1)"
             for arg in self.args_by_inout("out")
@@ -543,7 +546,6 @@ def _assemble_py_func_call(name: str, in_args: list[str], out_args: list[str]) -
 
 def main(srcdir: Path, templateloc: Path) -> None:
     env = Environment(loader=FileSystemLoader(templateloc))
-    env.filters["surround"] = lambda elems, pre, post: [pre + e + post for e in elems]
 
     funcs = [
         Function(name, srcdir)


### PR DESCRIPTION
Currently the code in `erfa_generator` and the templates that looks at the return value of ERFA C functions calls `Function.args_by_inout()`, but that always returns a `list`, which does not help convey that there can only be at most one status code or return value. The new `Function.c_retval` attribute makes that fact explicit and allows replacing several for-loops in the templates with more natural if-statements.