### PR TITLE
Implement the `Argument.cast_pointer` property

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -240,10 +240,10 @@ static void ufunc_loop_{{ func.pyname }}(
                 {%- endfor %}, {{ arg.name_for_call}});
         }
         else {
-            _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+            {{ arg.cast_pointer }}
         }
         {%- else %}
-        _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+        {{ arg.cast_pointer }}
         {%- endif %}
        {%- endfor %} {#- end of loop over 'in' #}
        {#- /* for inout arguments, set up output first,
@@ -251,7 +251,7 @@ static void ufunc_loop_{{ func.pyname }}(
        {%- for arg in func.args_by_inout('inout') %}
         {%- if arg.signature_shape != '()' %}
         if (!copy_{{ arg.name }}) {
-            _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+            {{ arg.cast_pointer }}
         }
         if (copy_{{ arg.name }}_in || {{ arg.name }} != {{ arg.name }}_in) {
             copy_to_{{ arg.ctype }}{{ arg.shape|join('') }}({{ arg.name }}_in
@@ -260,7 +260,7 @@ static void ufunc_loop_{{ func.pyname }}(
                 {%- endfor %}, {{ arg.name_for_call}});
         }
         {%- else %}
-        _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+        {{ arg.cast_pointer }}
         if ({{ arg.name }}_in != {{ arg.name }}) {
             memcpy({{ arg.name }}, {{ arg.name }}_in, {{ arg.size }}*sizeof({{ arg.ctype }}));
         }
@@ -270,10 +270,10 @@ static void ufunc_loop_{{ func.pyname }}(
        {%- for arg in func.args_by_inout('out') %}
         {%- if arg.signature_shape != '()' %}
         if (!copy_{{ arg.name }}) {
-            _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+            {{ arg.cast_pointer }}
         }
         {%- else %}
-        _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+        {{ arg.cast_pointer }}
         {%- endif %}
        {%- endfor %} {#- end of loop over 'out' #}
       {%- else %}
@@ -282,7 +282,7 @@ static void ufunc_loop_{{ func.pyname }}(
             */ #}
        {#- /* set up pointers to input/output arguments */ #}
        {%- for arg in func.args_by_inout('in|inout|out') %}
-        _{{ arg.name }} = (({{ arg.ctype }} (*){{ arg.cshape }}){{ arg.name }});
+        {{ arg.cast_pointer }}
        {%- endfor %}
        {#- /* copy from in to out for arugments changed in-place */ #}
        {%- for arg in func.args_by_inout('inout') %}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -213,6 +213,10 @@ class Argument(Variable):
         )
         return "\n".join(lines)
 
+    @functools.cached_property
+    def cast_pointer(self) -> str:
+        return f"_{self.name} = (({self.ctype} (*){self.cshape}){self.name});"
+
 
 class StatusCode(Variable):
     def __init__(self, ctype: str, doc: FunctionDoc, funcname: str) -> None:


### PR DESCRIPTION
The new property helps avoid code repetition in `erfa/ufunc.c.templ`.

I don't know C, so I'm not really sure what the generated C code is supposed to be doing and therefore it is possible the name I gave to the property is not good. If there is a better name then do let me know.