### PR TITLE
Avoid trivial status checks in Python wrappers

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -117,7 +117,7 @@ dt_bytes1 = np.dtype("S1")
 {#-
  # Define the status codes that this function returns.
  #}
-{%- if func.c_retval.inout_state == "stat" %}
+{%- if func.c_retval.can_fail %}
 
 
 STATUS_CODES["{{ func.pyname }}"] = {{ func.c_retval.to_python() }}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -251,6 +251,7 @@ class StatusCode(Variable):
                 r"(-?\w+) = ((?:[^=]+$)+)", status.group(1), re.MULTILINE
             )
         }
+        self.can_fail: Final = list(self._statuscodes) != [0]
 
     def to_python(self) -> str:
         return "\n".join(
@@ -378,14 +379,14 @@ class Function:
                 out_args=[arg.name for arg in self.args_by_inout("inout|out|stat|ret")],
             )
         ]
-        if isinstance(self.c_retval, StatusCode):
+        if isinstance(self.c_retval, StatusCode) and self.c_retval.can_fail:
             lines.append(f'check_errwarn({self.c_retval.name}, "{self.pyname}")')
         lines.extend(
             f"{arg.name} = {arg.name}.view(dt_bytes1)"
             for arg in self.args_by_inout("out")
             if arg.ctype == "char"
         )
-        if len(lines) == 1:
+        if len(lines) == 1 and not isinstance(self.c_retval, StatusCode):
             ufunc_call = f"{ufunc_name}({', '.join(arg_names)})"
             ret_val = (
                 ufunc_call


### PR DESCRIPTION
The Python wrappers automatically check the status codes of the corresponding ufuncs if the corresponding ERFA function returns any. However, several ERFA functions can only return status code 0, so checking that they have done that at runtime is just a waste of time. For example, on current `main`
```
$ ipython -i -c 'from erfa import ut1tai'
Python 3.11.12 (main, May 17 2025, 13:48:36) [Clang 20.1.4 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.13.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can change the editing mode of IPython to behave more like vi, or emacs.

In [1]: %timeit ut1tai(2453750.5, 0.892104561, -32.6659)
2.58 μs ± 3.68 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
but with this PR
```
In [1]: %timeit ut1tai(2453750.5, 0.892104561, -32.6659)
1.41 μs ± 1.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

<details>
  <summary>The difference between `erfa/core.py` generated by current `main` and this PR</summary>

```diff
17049,17053d17048
< STATUS_CODES["taitt"] = {
<     0: "OK",
< }
< 
< 
17115d17109
<     check_errwarn(c_retval, "taitt")
17119,17123d17112
< STATUS_CODES["taiut1"] = {
<     0: "OK",
< }
< 
< 
17187d17175
<     check_errwarn(c_retval, "taiut1")
17286,17290d17273
< STATUS_CODES["tcbtdb"] = {
<     0: "OK",
< }
< 
< 
17366d17348
<     check_errwarn(c_retval, "tcbtdb")
17370,17374d17351
< STATUS_CODES["tcgtt"] = {
<     0: "OK",
< }
< 
< 
17435d17411
<     check_errwarn(c_retval, "tcgtt")
17439,17443d17414
< STATUS_CODES["tdbtcb"] = {
<     0: "OK",
< }
< 
< 
17519d17489
<     check_errwarn(c_retval, "tdbtcb")
17523,17527d17492
< STATUS_CODES["tdbtt"] = {
<     0: "OK",
< }
< 
< 
17601d17565
<     check_errwarn(c_retval, "tdbtt")
17605,17609d17568
< STATUS_CODES["tttai"] = {
<     0: "OK",
< }
< 
< 
17671d17629
<     check_errwarn(c_retval, "tttai")
17675,17679d17632
< STATUS_CODES["tttcg"] = {
<     0: "OK",
< }
< 
< 
17740d17692
<     check_errwarn(c_retval, "tttcg")
17744,17748d17695
< STATUS_CODES["tttdb"] = {
<     0: "OK",
< }
< 
< 
17822d17768
<     check_errwarn(c_retval, "tttdb")
17826,17830d17771
< STATUS_CODES["ttut1"] = {
<     0: "OK",
< }
< 
< 
17893d17833
<     check_errwarn(c_retval, "ttut1")
17897,17901d17836
< STATUS_CODES["ut1tai"] = {
<     0: "OK",
< }
< 
< 
17965d17899
<     check_errwarn(c_retval, "ut1tai")
17969,17973d17902
< STATUS_CODES["ut1tt"] = {
<     0: "OK",
< }
< 
< 
18036d17964
<     check_errwarn(c_retval, "ut1tt")
```

</details>