### PR TITLE
Rework argument role tracking in code generation

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -133,14 +133,14 @@ STATUS_CODES["{{ func.pyname }}"] = {{ func.c_retval.to_python() }}
 {%- endif %}
 
 
-def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }}):
+def {{ func.pyname }}({{ func.py_args|map(attribute='name')|join(', ') }}):
     """
     {{ func.doc.first_sentence | indent(2)}}
-    {%- if func.args_by_inout('in|inout') %}
+    {%- if func.py_args %}
 
     Parameters
     ----------
-    {%- for arg in func.args_by_inout('in|inout') %}
+    {%- for arg in func.py_args %}
     {{ arg.name }} : {{ arg.ctype }} array
     {%- endfor %}
     {%- endif %}
@@ -150,15 +150,15 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
     {%- if func.result_tuple %}
     A ``{{ func.result_tuple.name }}`` namedtuple with the following attributes:
     {%- endif %}
-    {%- for arg in func.args_by_inout('inout|out|ret') %}
+    {%- for arg in func.py_return %}
     {{ arg.name }} : {{ arg.ctype }} array
     {%- endfor %}
 
     Notes
     -----
     Wraps ERFA function ``{{ func.name }}``.
-    {%- if func.args_by_inout('inout') %} Note that, unlike the erfa routine,
-    the python wrapper does not change {{ func.args_by_inout('inout')
+    {%- if func.inout_args %} Note that, unlike the erfa routine,
+    the python wrapper does not change {{ func.inout_args
     | map(attribute='name')|join(', ') }} in-place.
     {%- endif %} The ERFA documentation is::
 

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -159,24 +159,24 @@ static void ufunc_loop_{{ func.pyname }}(
        * Pointers to each argument, required step size
        */ #}
   {#- /* normal input arguments */ #}
-  {%- for arg in func.args_by_inout('in') %}
+  {%- for arg in func.in_args %}
     char *{{ arg.name }} = *args++;
     npy_intp s_{{ arg.name }} = *steps++;
   {%- endfor -%}
   {#- /* for in part of in-place arguments, we need a different name */ #}
-  {%- for arg in func.args_by_inout('inout') %}
+  {%- for arg in func.inout_args %}
     char *{{ arg.name }}_in = *args++;
     npy_intp s_{{ arg.name }}_in = *steps++;
   {%- endfor -%}
   {#- /* out part of input, and output arguments, including status */ #}
-  {%- for arg in func.args_by_inout('inout|out|stat|ret') %}
+  {%- for arg in func.ufunc_return %}
     char *{{ arg.name }} = *args++;
     npy_intp s_{{ arg.name }} = *steps++;
   {%- endfor -%}
   {#- /*
        * Cast pointers and possible contiguous buffers (for gufuncs)
        */ #}
-  {%- for arg in func.args_by_inout('in|inout|out') %}
+  {%- for arg in func.c_args %}
    {%- if arg.signature_shape == '()' or arg.ctype == 'eraLDBODY'  %}
     {{ arg.ctype }} (*_{{ arg.name }}){{ arg.cshape }};
    {%- else %}
@@ -193,7 +193,7 @@ static void ufunc_loop_{{ func.pyname }}(
        */ #}
   {%- if func.signature %}
    {#- /* loop step sizes and whether copies are needed */ #}
-   {%- for arg in func.args_by_inout('in') %}
+   {%- for arg in func.in_args %}
     {#- /* only LDBODY has non-fixed dimension; it is always first */ #}
     {%- if arg.ctype == 'eraLDBODY' %}
     int nb = (int)dimensions[0];  /* Refuse to worry about INT_MAX */
@@ -220,10 +220,10 @@ static void ufunc_loop_{{ func.pyname }}(
        * Actual inner loop, increasing all pointers by their steps
        */ #}
     for (i_o = 0; i_o < n_o;
-         i_o++ {%- for arg in func.args_by_inout('in|inout|out|stat|ret') -%}
+         i_o++ {%- for arg in func.args -%}
              , {{ arg.name }} += s_{{ arg.name }}
              {%- endfor -%}
-             {%- for arg in func.args_by_inout('inout') -%}
+             {%- for arg in func.inout_args -%}
              , {{ arg.name }}_in += s_{{ arg.name }}_in
              {%- endfor -%}) {
       {%- if func.signature %}
@@ -231,7 +231,7 @@ static void ufunc_loop_{{ func.pyname }}(
             * GENERALIZED UFUNC, prepare for call.
             */ #}
        {#- /* copy input arguments to buffer if needed */ #}
-       {%- for arg in func.args_by_inout('in') %}
+       {%- for arg in func.in_args %}
         {%- if arg.signature_shape != '()' %}
         if (copy_{{ arg.name }}) {
             {{ arg.copy_elements("to") }}
@@ -245,7 +245,7 @@ static void ufunc_loop_{{ func.pyname }}(
        {%- endfor %} {#- end of loop over 'in' #}
        {#- /* for inout arguments, set up output first,
               and then copy to it if needed */ #}
-       {%- for arg in func.args_by_inout('inout') %}
+       {%- for arg in func.inout_args %}
         {%- if arg.signature_shape != '()' %}
         if (!copy_{{ arg.name }}) {
             {{ arg.cast_pointer }}
@@ -261,7 +261,7 @@ static void ufunc_loop_{{ func.pyname }}(
         {%- endif %}
        {%- endfor %} {#- end of loop over 'inout' #}
        {#- /* set up gufunc outputs */ #}
-       {%- for arg in func.args_by_inout('out') %}
+       {%- for arg in func.out_args %}
         {%- if arg.signature_shape != '()' %}
         if (!copy_{{ arg.name }}) {
             {{ arg.cast_pointer }}
@@ -275,11 +275,11 @@ static void ufunc_loop_{{ func.pyname }}(
             * NORMAL UFUNC, prepare for call
             */ #}
        {#- /* set up pointers to input/output arguments */ #}
-       {%- for arg in func.args_by_inout('in|inout|out') %}
+       {%- for arg in func.c_args %}
         {{ arg.cast_pointer }}
        {%- endfor %}
        {#- /* copy from in to out for arugments changed in-place */ #}
-       {%- for arg in func.args_by_inout('inout') %}
+       {%- for arg in func.inout_args %}
         if ({{ arg.name }}_in != {{ arg.name }}) {
             memcpy({{ arg.name }}, {{ arg.name }}_in, {{ arg.size }}*sizeof({{ arg.ctype }}));
         }
@@ -289,16 +289,14 @@ static void ufunc_loop_{{ func.pyname }}(
            * call the actual erfa function
            */ #}
         {% if func.c_retval %}_{{ func.c_retval.name }} = {% endif %}{{ func.name
-        }}({{ func.args_by_inout('in|inout|out') |
-                    map(attribute='name_for_call') |
-                    join(', ') }});
+        }}({{ func.c_args | map(attribute='name_for_call') | join(', ') }});
       {#- /* store any return values */ #}
       {%- if func.c_retval %}
         *(({{ func.c_retval.ctype }} *){{ func.c_retval.name }}) = _{{ func.c_retval.name }};
       {%- endif %}
       {%- if func.signature %}
        {#- /* for generalized ufunc, copy output from buffer if needed */ #}
-       {%- for arg in func.args_by_inout('inout|out') %}
+       {%- for arg in func.inout_or_out_args %}
         {%- if arg.signature_shape != '()' %}
         if (copy_{{ arg.name }}) {
             {{ arg.copy_elements("from") }}
@@ -737,10 +735,9 @@ PyMODINIT_FUNC PyInit_ufunc(void)
            as these do not get copied */ #}
     {%- for func in funcs %}
     {%- if not func.user_dtype %}
-    static char types_{{ func.pyname }}[{{ func.args_by_inout('in|inout')|count
-                                         + func.args_by_inout('inout|out|ret|stat')|count }}] = {
-    {%- for arg in func.args_by_inout('in|inout') %}{{ arg.npy_type }}, {% endfor %}
-    {%- for arg in func.args_by_inout('inout|out|ret|stat') -%}
+    static char types_{{ func.pyname }}[{{ func.py_args|count + func.ufunc_return|count }}] = {
+    {%- for arg in func.py_args %}{{ arg.npy_type }}, {% endfor %}
+    {%- for arg in func.ufunc_return -%}
     {%- if loop.index > 1 %}, {% endif %}{{ arg.npy_type }}{%- endfor -%}
     };
     static PyUFuncGenericFunction funcs_{{ func.pyname }}[1] = { &ufunc_loop_{{ func.pyname }} };
@@ -907,7 +904,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     {%- if not func.user_dtype %}
     ufunc = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignature(
         funcs_{{ func.pyname }}, data, types_{{ func.pyname }},
-        1, {{ func.args_by_inout('in|inout')|count }}, {{ func.args_by_inout('inout|out|ret|stat')|count }}, PyUFunc_None,
+        1, {{ func.py_args|count }}, {{ func.ufunc_return|count }}, PyUFunc_None,
         "{{ func.pyname }}",
         "UFunc wrapper for {{ func.name }}",
         0, {% if func.signature -%} "{{ func.signature }}" {%- else -%} NULL {%- endif -%});
@@ -917,18 +914,18 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     {%- else %}
     ufunc = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignature(
         NULL, NULL, NULL,
-        0, {{ func.args_by_inout('in|inout')|count }}, {{ func.args_by_inout('inout|out|ret|stat')|count }}, PyUFunc_None,
+        0, {{ func.py_args|count }}, {{ func.ufunc_return|count }}, PyUFunc_None,
         "{{ func.pyname }}",
         "UFunc wrapper for {{ func.name }}",
         0, {% if func.signature -%} "{{ func.signature }}" {%- else -%} NULL {%- endif -%});
     if (ufunc == NULL) {
         goto fail;
     }
-    {%- for arg in func.args_by_inout('in|inout') %}
+    {%- for arg in func.py_args %}
     dtypes[{{ loop.index - 1 }}] = {{ arg.dtype }};
     {%- endfor %}
-    {%- for arg in func.args_by_inout('inout|out|ret|stat') %}
-    dtypes[{{ loop.index - 1 + func.args_by_inout('in|inout')|count }}] = {{ arg.dtype }};
+    {%- for arg in func.ufunc_return %}
+    dtypes[{{ loop.index - 1 + func.py_args|count }}] = {{ arg.dtype }};
     {%- endfor %}
     status = PyUFunc_RegisterLoopForDescr(
         ufunc, {{ func.user_dtype }},

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -106,16 +106,6 @@ class Argument(Variable):
         )
         super().__init__(ctype, ptr_name_arr.removeprefix("*").split("[", 1)[0])
 
-    @functools.cached_property
-    def inout_state(self) -> str:
-        if self.name in self.doc.input:
-            return "in"
-        if self.name in self.doc.inout:
-            return "inout"
-        if self.name in self.doc.output:
-            return "out"
-        return ""
-
     @property
     def name_for_call(self) -> str:
         """How the argument should be used in the call to the ERFA function.
@@ -231,7 +221,6 @@ class Argument(Variable):
 
 class StatusCode(Variable):
     def __init__(self, ctype: str, doc: FunctionDoc, funcname: str) -> None:
-        self.inout_state = "stat"
         super().__init__(ctype)
 
         status = re.search(
@@ -260,10 +249,7 @@ class StatusCode(Variable):
 
 
 class Return(Variable):
-
-    def __init__(self, ctype: str) -> None:
-        self.inout_state = "ret"
-        super().__init__(ctype)
+    pass
 
 
 class ResultTuple:
@@ -304,9 +290,16 @@ class Function:
             raise RuntimeError(f"cannot find {name}() definition in {file}")
 
         self.doc: Final = FunctionDoc(search.group(3), self.pyname)
-        self.args: Final[list[Variable]] = [
-            Argument(arg, self.doc) for arg in re.findall("[^,]+", search.group(2))
-        ]
+        args = [Argument(arg, self.doc) for arg in re.findall("[^,]+", search.group(2))]
+        self.in_args: Final = tuple(a for a in args if a.name in self.doc.input)
+        self.inout_args: Final = tuple(a for a in args if a.name in self.doc.inout)
+        self.out_args: Final = tuple(a for a in args if a.name in self.doc.output)
+
+        self.py_args: Final = (*self.in_args, *self.inout_args)
+        self.c_args: Final = (*self.py_args, *self.out_args)
+        self.inout_or_out_args: Final = (*self.inout_args, *self.out_args)
+
+        self.args: Final[list[Variable]] = list(self.c_args)
         if (ret := search.group(1)) != "void":
             self.c_retval = (
                 StatusCode(ret, self.doc, name)
@@ -315,30 +308,29 @@ class Function:
             )
             self.args.append(self.c_retval)
 
-        self.result_tuple: Final = (
-            ResultTuple(self.pyname, py_return)
-            if len(py_return := self.args_by_inout("inout|out|ret")) > 1
+    @functools.cached_property
+    def result_tuple(self) -> ResultTuple | None:
+        return (
+            ResultTuple(self.pyname, self.py_return)
+            if len(self.py_return) > 1
             else None
         )
 
-    def args_by_inout(self, inout_filter):
-        """
-        Gives all of the arguments and/or returned values, depending on whether
-        they are inputs, outputs, etc.
+    @functools.cached_property
+    def py_return(self) -> tuple[Argument | Return, ...]:
+        return (
+            (*self.inout_or_out_args, self.c_retval)
+            if isinstance(self.c_retval, Return)
+            else self.inout_or_out_args
+        )
 
-        The value for `inout_filter` should be a string containing anything
-        that arguments' `inout_state` attribute produces.  Currently, that can be:
-
-          * "in" : input
-          * "out" : output
-          * "inout" : something that's could be input or output (e.g. a struct)
-          * "ret" : the return value of the C function
-          * "stat" : the return value of the C function if it is a status code
-
-        It can also be a "|"-separated string giving inout states to OR
-        together.
-        """
-        return [arg for arg in self.args if arg.inout_state in inout_filter.split("|")]
+    @functools.cached_property
+    def ufunc_return(self) -> tuple[Variable, ...]:
+        return (
+            self.inout_or_out_args
+            if self.c_retval is None
+            else (*self.inout_or_out_args, self.c_retval)
+        )
 
     @property
     def user_dtype(self):
@@ -349,7 +341,7 @@ class Function:
         should be a generalized ufunc.
         """
         user_dtype = None
-        for arg in self.args_by_inout('in|inout|out'):
+        for arg in self.c_args:
             if arg.ctype == 'eraLDBODY':
                 return arg.dtype
             if user_dtype is None and arg.dtype not in ("dt_double", "dt_int"):
@@ -360,30 +352,31 @@ class Function:
     @property
     def signature(self):
         """Possible signature, if this function should be a gufunc."""
-        if all(arg.signature_shape == '()'
-               for arg in self.args_by_inout('in|inout|out')):
-            return None
-
-        return '->'.join(
-            [','.join([arg.signature_shape for arg in args])
-             for args in (self.args_by_inout('in|inout'),
-                          self.args_by_inout('inout|out|ret|stat'))])
+        return (
+            (
+                ",".join(arg.signature_shape for arg in self.py_args)
+                + "->"
+                + ",".join(arg.signature_shape for arg in self.ufunc_return)
+            )
+            if any(arg.signature_shape != "()" for arg in self.c_args)
+            else None
+        )
 
     def generate_python_body(self) -> str:
         ufunc_name = f"ufunc.{self.pyname}"
-        arg_names = [arg.name for arg in self.args_by_inout("in|inout")]
+        arg_names = [arg.name for arg in self.py_args]
         lines = [
             _assemble_func_call(
                 ufunc_name,
                 in_args=arg_names,
-                out_args=[arg.name for arg in self.args_by_inout("inout|out|stat|ret")],
+                out_args=[arg.name for arg in self.ufunc_return],
             )
         ]
         if isinstance(self.c_retval, StatusCode) and self.c_retval.can_fail:
             lines.append(f'check_errwarn({self.c_retval.name}, "{self.pyname}")')
         lines.extend(
             f"{arg.name} = {arg.name}.view(dt_bytes1)"
-            for arg in self.args_by_inout("out")
+            for arg in self.out_args
             if arg.ctype == "char"
         )
         if len(lines) == 1 and not isinstance(self.c_retval, StatusCode):
@@ -395,7 +388,7 @@ class Function:
             )
             return f"return {ret_val}"
         ret_val = (
-            self.args_by_inout("inout|out|ret")[0].name
+            self.py_return[0].name
             if self.result_tuple is None
             else self.result_tuple.create()
         )
@@ -403,11 +396,9 @@ class Function:
         return "\n".join(lines)
 
     def inner_loop_steps_and_copies(self) -> str:
-        in_only = [a.inner_loop_steps_and_copy() for a in self.args_by_inout("in")]
-        inout = [
-            a.inner_loop_steps_and_copy("_in") for a in self.args_by_inout("inout")
-        ]
-        out = [a.inner_loop_steps_and_copy() for a in self.args_by_inout("inout|out")]
+        in_only = [a.inner_loop_steps_and_copy() for a in self.in_args]
+        inout = [a.inner_loop_steps_and_copy("_in") for a in self.inout_args]
+        out = [a.inner_loop_steps_and_copy() for a in self.inout_or_out_args]
         return "\n".join(filter(None, in_only + inout + out))
 
 
@@ -526,14 +517,14 @@ class TestFunction:
                     (arg.lstrip("0") or "0") if arg.isdigit() else arg.removeprefix("&")
                     for arg in arguments
                 ]
-                out_args = args[len(self.func.args_by_inout("in")) :]
+                out_args = args[len(self.func.in_args) :]
                 # If the call assigned something, that will have been the status.
                 # Prepend any arguments assigned in the call.
                 if " = " in name:
                     status, name = name.split(" = ", 1)
                     out_args.append(status)
                 line = _assemble_func_call(
-                    name, args[: len(self.func.args_by_inout("in|inout"))], out_args
+                    name, args[: len(self.func.py_args)], out_args
                 )
                 if 'astrom' in out_args:
                     out.append(line)


### PR DESCRIPTION
Some ERFA function arguments are inputs to the function, others are pointers to where the output is supposed to be written, and a few are (pointers to) structs with some fields being function inputs and others locations for the output. The code generation in `erfa_generator` and the templates has to keep track of the role of each argument. If the ERFA function returns a status code or a result value then that has to be tracked too. Currently this is done by the `Function.args_by_inout()` method, which checks the role of each argument every time it is called, but that has several shortcomings. For example, both `Return` and `StatusCode` have an `inout_state` attribute which is redundant because it is fully determined by the class, but it is nonetheless needed to simplify `Function.args_by_inout()` implementation.

The new approach is to replace the single `Function.args_by_inout()` method that can produce different lists based on its argument with a few different `Function` attributes and properties. In practice the new approach is simpler to work with. For example, IDEs can much more easily suggest completions for attributes and properties than for the `Function.args_by_inout()` argument.

There are no changes to any of the files `erfa_generator` creates.