### PR TITLE
WHL: drop win32 support (stop distributing wheels)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,6 @@ jobs:
         - pp3*-macosx_x86_64
         - pp3*-macosx_arm64
         # Windows wheels
-        - cp3*-win32
         - cp3*-win_amd64
         - cp3*-win_arm64
         - pp3*-win_amd64


### PR DESCRIPTION
Following numpy
https://mail.python.org/archives/list/numpy-discussion@python.org/thread/FGVCDS5JICVIUVBISGWZNQ46QZ3XX5PB/#TTSOQQ3XLXXK52CZYMN7MALJQEI65UDN