### PR TITLE
Simplify MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,3 @@
-include README.rst
-include pyproject.toml
-include setup.cfg
-include erfa_generator.py
-
-recursive-include erfa *.c *.h *.templ
-
-recursive-include licenses *
 recursive-include liberfa/erfa *
 
 exclude liberfa/erfa/Makefile
@@ -22,6 +14,5 @@ prune liberfa/erfa/autom4te.cache
 prune liberfa/erfa/src/.deps
 
 exclude .gitignore
-prune build
 
-global-exclude *.pyc *.o
+global-exclude *.o


### PR DESCRIPTION
The `MANIFEST.in` file controls what files are included in a source distribution, but the `MANIFEST.in` in current `main` lists several files that would be included anyways and excludes many files that are not included to begin with. I suspect the file could be simplified even more, but I don't know enough about compiling the ERFA C code, so I shouldn't edit any configuration about it.