### PR TITLE
Allow installing an sdist with latest `setuptools_scm`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,14 +130,15 @@ def get_extensions() -> list[setuptools.Extension]:
 
 
 def guess_next_dev(version: ScmVersion) -> str:
+    version_string = str(version.tag)
     erfa_version = git.parse(LIBERFADIR, config=Configuration(root=LIBERFADIR))
     if erfa_version is None:
-        raise RuntimeError("unable to determine liberfa/erfa version")
+        # Must be installing from an sdist. Any warnings should have been dealt with
+        # when the sdist was built, so we can assume version_string is correct.
+        return version_string
     if not erfa_version.exact:
         warn(f"liberfa/erfa not at a tagged release, but at {erfa_version}")
-
     erfa_tag = erfa_version.format_with("{tag}")
-    version_string = str(version.tag)
 
     if version.exact:
         if not version_string.startswith(erfa_tag):


### PR DESCRIPTION
If the build requirements in `pyproject.toml` are modified
```diff
-    "setuptools_scm>=8.0.0",
+    "setuptools_scm>=8.0.0,<10",
```
to force using `setuptools_scm==9.2.2` then building a source distribution of current `main` with
```
python -m build --sdist
```
and installing it (outside the `pyerfa` repository) succeeds. But without the aforementioned change in `pyproject.toml` the latest `setuptools_scm` is used, in which case building a source distribution of current `main` seems to succeed, but trying to install it fails. This PR allows building and installing a source distribution with the latest `setuptools_scm` without causing (obvious) problems with `setuptools_scm==9.2.2`.

#### EDIT:

Apparently the change is not directly caused by `setuptools_scm` but instead by the new [`vcs-versioning`](https://pypi.org/project/vcs-versioning/) release, which was not a dependency for `setuptools_scm<10`, but is a dependency now.