### PR TITLE
Implement the `Argument.memcpy_if_needed` property

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -255,9 +255,7 @@ static void ufunc_loop_{{ func.pyname }}(
         }
         {%- else %}
         {{ arg.cast_pointer }}
-        if ({{ arg.name }}_in != {{ arg.name }}) {
-            memcpy({{ arg.name }}, {{ arg.name }}_in, {{ arg.size }}*sizeof({{ arg.ctype }}));
-        }
+        {{ arg.memcpy_if_needed | indent(8) }}
         {%- endif %}
        {%- endfor %} {#- end of loop over 'inout' #}
        {#- /* set up gufunc outputs */ #}
@@ -280,9 +278,7 @@ static void ufunc_loop_{{ func.pyname }}(
        {%- endfor %}
        {#- /* copy from in to out for arugments changed in-place */ #}
        {%- for arg in func.inout_args %}
-        if ({{ arg.name }}_in != {{ arg.name }}) {
-            memcpy({{ arg.name }}, {{ arg.name }}_in, {{ arg.size }}*sizeof({{ arg.ctype }}));
-        }
+        {{ arg.memcpy_if_needed | indent(8) }}
        {%- endfor %}
       {%- endif %} {#- end of gufunc/ufunc preparation #}
       {#- /*

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -162,15 +162,6 @@ class Argument(Variable):
         return len(self.shape)
 
     @property
-    def size(self) -> int | None:
-        size = 1
-        for s in self.shape:
-            if s is None:
-                return None
-            size *= s
-        return size
-
-    @property
     def cshape(self) -> str:
         elems = []
         for s in self.shape:
@@ -217,6 +208,19 @@ class Argument(Variable):
         func_name = f"copy_{direction}_{self.ctype}{shape_description}"
         args = [name, *[f"is_{name}{i}" for i in range(self.ndim)], self.name_for_call]
         return _assemble_func_call(func_name, args) + ";"
+
+    @functools.cached_property
+    def memcpy_if_needed(self) -> str:
+        size = 1
+        for s in self.shape:
+            if s is None:
+                raise RuntimeError("{self.name} size not known at compile-time")
+            size *= s
+        return (
+            f"if ({self.name}_in != {self.name}) {{\n"
+            f"    memcpy({self.name}, {self.name}_in, {size}*sizeof({self.ctype}));\n"
+            "}"
+        )
 
 
 class StatusCode(Variable):


### PR DESCRIPTION
In general replacing code in the templates with code in `erfa_generator.py` allows reducing code duplication, and Python code can be checked with tools such as Ruff or Mypy. In this particular case there is an additional benefit because implementing `Argument.memcpy_if_needed` allows `Argument.size` to be removed.