### PR TITLE
Move code from `ufunc.c.templ` to `erfa_generator.py`

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -220,12 +220,7 @@ static void ufunc_loop_{{ func.pyname }}(
        * Actual inner loop, increasing all pointers by their steps
        */ #}
     for (i_o = 0; i_o < n_o;
-         i_o++ {%- for arg in func.args -%}
-             , {{ arg.name }} += s_{{ arg.name }}
-             {%- endfor -%}
-             {%- for arg in func.inout_args -%}
-             , {{ arg.name }}_in += s_{{ arg.name }}_in
-             {%- endfor -%}) {
+         i_o++, {{ func.increment_arg_pointers }}) {
       {%- if func.signature %}
        {#- /*
             * GENERALIZED UFUNC, prepare for call.
@@ -233,11 +228,9 @@ static void ufunc_loop_{{ func.pyname }}(
        {#- /* copy input arguments to buffer if needed */ #}
        {%- for arg in func.in_args %}
         {%- if arg.signature_shape != '()' %}
-        if (copy_{{ arg.name }}) {
-            {{ arg.copy_elements("to") }}
-        }
+        {{ arg.cast_pointer_if_needed | indent(8) }}
         else {
-            {{ arg.cast_pointer }}
+            {{ arg.copy_elements("to") }}
         }
         {%- else %}
         {{ arg.cast_pointer }}
@@ -247,9 +240,7 @@ static void ufunc_loop_{{ func.pyname }}(
               and then copy to it if needed */ #}
        {%- for arg in func.inout_args %}
         {%- if arg.signature_shape != '()' %}
-        if (!copy_{{ arg.name }}) {
-            {{ arg.cast_pointer }}
-        }
+        {{ arg.cast_pointer_if_needed | indent(8) }}
         if (copy_{{ arg.name }}_in || {{ arg.name }} != {{ arg.name }}_in) {
             {{ arg.copy_elements("to", "_in") }}
         }
@@ -261,9 +252,7 @@ static void ufunc_loop_{{ func.pyname }}(
        {#- /* set up gufunc outputs */ #}
        {%- for arg in func.out_args %}
         {%- if arg.signature_shape != '()' %}
-        if (!copy_{{ arg.name }}) {
-            {{ arg.cast_pointer }}
-        }
+        {{ arg.cast_pointer_if_needed | indent(8) }}
         {%- else %}
         {{ arg.cast_pointer }}
         {%- endif %}
@@ -281,15 +270,7 @@ static void ufunc_loop_{{ func.pyname }}(
         {{ arg.memcpy_if_needed | indent(8) }}
        {%- endfor %}
       {%- endif %} {#- end of gufunc/ufunc preparation #}
-      {#- /*
-           * call the actual erfa function
-           */ #}
-        {% if func.c_retval %}_{{ func.c_retval.name }} = {% endif %}{{ func.name
-        }}({{ func.c_args | map(attribute='name_for_call') | join(', ') }});
-      {#- /* store any return values */ #}
-      {%- if func.c_retval %}
-        *(({{ func.c_retval.ctype }} *){{ func.c_retval.name }}) = _{{ func.c_retval.name }};
-      {%- endif %}
+        {{ func.erfa_call | indent(8) }}
       {%- if func.signature %}
        {#- /* for generalized ufunc, copy output from buffer if needed */ #}
        {%- for arg in func.inout_or_out_args %}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -202,6 +202,16 @@ class Argument(Variable):
     def cast_pointer(self) -> str:
         return f"_{self.name} = (({self.ctype} (*){self.cshape}){self.name});"
 
+    @functools.cached_property
+    def cast_pointer_if_needed(self) -> str:
+        return "\n".join(
+            [
+                f"if (!copy_{self.name}) {{",
+                f"    {self.cast_pointer}",
+                "}",
+            ]
+        )
+
     def copy_elements(self, direction: str, name_suffix: str = "") -> str:
         name = self.name + name_suffix
         shape_description = "".join(str(n) for n in self.shape if n is not None)
@@ -303,14 +313,12 @@ class Function:
         self.c_args: Final = (*self.py_args, *self.out_args)
         self.inout_or_out_args: Final = (*self.inout_args, *self.out_args)
 
-        self.args: Final[list[Variable]] = list(self.c_args)
         if (ret := search.group(1)) != "void":
             self.c_retval = (
                 StatusCode(ret, self.doc, name)
                 if ret == "int" and self.pyname not in ("tpors", "tporv")
                 else Return(ret)
             )
-            self.args.append(self.c_retval)
 
     @functools.cached_property
     def result_tuple(self) -> ResultTuple | None:
@@ -404,6 +412,25 @@ class Function:
         inout = [a.inner_loop_steps_and_copy("_in") for a in self.inout_args]
         out = [a.inner_loop_steps_and_copy() for a in self.inout_or_out_args]
         return "\n".join(filter(None, in_only + inout + out))
+
+    @functools.cached_property
+    def increment_arg_pointers(self) -> str:
+        return ", ".join(
+            [f"{arg.name} += s_{arg.name}" for arg in self.in_args + self.ufunc_return]
+            + [f"{arg.name}_in += s_{arg.name}_in" for arg in self.inout_args],
+        )
+
+    @functools.cached_property
+    def erfa_call(self) -> str:
+        call = _assemble_func_call(self.name, [a.name_for_call for a in self.c_args])
+        return (
+            (
+                f"_{c_retval.name} = {call};\n"
+                f"*(({c_retval.ctype} *){c_retval.name}) = _{c_retval.name};"
+            )
+            if (c_retval := self.c_retval)
+            else f"{call};"
+        )
 
 
 class Constant:


### PR DESCRIPTION
The new Python code helps avoid code repetition in the `erfa/ufunc.c` template. Furthermore, Python code can be checked with tools such as Ruff or Mypy and there is better IDE support. If we keep moving code from the templates to `erfa_generator.py` then it might eventually become possible to drop `jinja2` as a build requirement.