### PR TITLE
Fix converting octal integers in `erfa_generator`

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -542,9 +542,10 @@ class TestFunction:
                 name, arguments = _get_funcname_and_args(
                     line, self.func.name, f"erfa_ufunc.{self.func.pyname}"
                 )
-                # Remove leading zeros from numbers since python cannot deal with them.
                 args = [
-                    (arg.lstrip("0") or "0") if arg.isdigit() else arg.removeprefix("&")
+                    str(int(arg, 8))  # convert any C octal integer literals
+                    if arg.startswith("0") and arg.isdigit()
+                    else arg.removeprefix("&")
                     for arg in arguments
                 ]
                 out_args = args[len(self.func.in_args) :]


### PR DESCRIPTION
The C source code for ERFA tests contains the integer literals `06` and `01`. Most people (apparently including the author of 1effd5ffdc80ac91002e1e7f533753397671e56b) might think that such leading zeros can simply be dropped without changing what the literal represents, but in C the leading zero actually means the integer is written in octal (see also [PEP 3127 – Integer Literal Support and Syntax](https://peps.python.org/pep-3127/#removal-of-old-octal-syntax)). This has not caused problems in practice because dropping the leading zero happens to work with the values `erfa_generator` encounters.