### PR TITLE
Speed up checking status codes if they are all 0

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -66,9 +66,9 @@ STATUS_CODES_REMAP = {"cal2jd": {-3: 3}}
 
 
 def check_errwarn(statcodes, func_name):
-    if not statcodes.any():
-        return
     statcodes = np.atleast_1d(statcodes)
+    if not statcodes.nonzero()[0].size:  # faster than .any()
+        return
     # Remap any errors into warnings in the STATUS_CODES_REMAP dict.
     if func_name in STATUS_CODES_REMAP:
         for before, after in STATUS_CODES_REMAP[func_name].items():


### PR DESCRIPTION
On current `main` (and with `numpy==2.4.6`)
```
$ cat timings.py 
import numpy as np

from erfa import eform

scalar = 1
small_arr = np.ones(1000, dtype=np.int32)
large_arr = np.ones(1_000_000, dtype=np.int32)
$ ipython -i timings.py 
Python 3.11.12 (main, May 17 2025, 13:48:36) [Clang 20.1.4 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.14.1 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can change the editing mode of IPython to behave more like vi, or emacs.

In [1]: %timeit eform(scalar)
2.44 μs ± 15.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit eform(small_arr)
4.17 μs ± 59.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit eform(large_arr)
4.67 ms ± 26.3 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
but in this PR
```
In [1]: %timeit eform(scalar)
2.14 μs ± 12.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit eform(small_arr)
3.73 μs ± 7.39 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit eform(large_arr)
4.34 ms ± 36.4 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
I didn't bother benchmarking non-zero status codes because I don't care about performance off the happy path.