### PR TITLE
Move normal and generalized ufunc code generation differences from `ufunc.c` template to `erfa_generator`

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -154,98 +154,11 @@ static void ufunc_loop_{{ func.pyname }}(
 {
     {{ func.init_ufunc_loop_local_vars | indent(4) }}
   {#- /*
-       * For GENERALIZED UFUNCS - inner loop steps, needs for copying.
-       */ #}
-  {%- if func.signature %}
-   {#- /* loop step sizes and whether copies are needed */ #}
-   {%- for arg in func.in_args %}
-    {#- /* only LDBODY has non-fixed dimension; it is always first */ #}
-    {%- if arg.ctype == 'eraLDBODY' %}
-    int nb = (int)dimensions[0];  /* Refuse to worry about INT_MAX */
-    {%- endif %}
-   {%- endfor %}
-    {{ func.inner_loop_steps_and_copies() | indent(4) }}
-   {#- /* if needed, allocate memory for contiguous eraLDBODY copies */ #}
-   {%- if func.user_dtype == 'dt_eraLDBODY' %}
-    if (copy_b) {
-        // Note that we can't use PyArray_malloc here as it is an alias to PyMem_RawMalloc
-        // which is not available in the Python limited API
-        _b = malloc(nb * sizeof(eraLDBODY));
-        if (_b == NULL) {
-            PyErr_NoMemory();
-            return;
-        }
-    }
-    else { {#- /* just to keep compiler happy */ #}
-        _b = NULL;
-    }
-   {%- endif %}
-  {%- endif %} {#- /* end of GUFUNC inner loop definitions */ #}
-  {#- /*
        * Actual inner loop, increasing all pointers by their steps
        */ #}
     for (i_o = 0; i_o < n_o;
          i_o++, {{ func.increment_arg_pointers }}) {
-      {%- if func.signature %}
-       {#- /*
-            * GENERALIZED UFUNC, prepare for call.
-            */ #}
-       {#- /* copy input arguments to buffer if needed */ #}
-       {%- for arg in func.in_args %}
-        {%- if arg.signature_shape != '()' %}
-        {{ arg.cast_pointer_if_needed | indent(8) }}
-        else {
-            {{ arg.copy_elements("to") }}
-        }
-        {%- else %}
-        {{ arg.cast_pointer }}
-        {%- endif %}
-       {%- endfor %} {#- end of loop over 'in' #}
-       {#- /* for inout arguments, set up output first,
-              and then copy to it if needed */ #}
-       {%- for arg in func.inout_args %}
-        {%- if arg.signature_shape != '()' %}
-        {{ arg.cast_pointer_if_needed | indent(8) }}
-        if (copy_{{ arg.name }}_in || {{ arg.name }} != {{ arg.name }}_in) {
-            {{ arg.copy_elements("to", "_in") }}
-        }
-        {%- else %}
-        {{ arg.cast_pointer }}
-        {{ arg.memcpy_if_needed | indent(8) }}
-        {%- endif %}
-       {%- endfor %} {#- end of loop over 'inout' #}
-       {#- /* set up gufunc outputs */ #}
-       {%- for arg in func.out_args %}
-        {%- if arg.signature_shape != '()' %}
-        {{ arg.cast_pointer_if_needed | indent(8) }}
-        {%- else %}
-        {{ arg.cast_pointer }}
-        {%- endif %}
-       {%- endfor %} {#- end of loop over 'out' #}
-      {%- else %}
-       {#- /*
-            * NORMAL UFUNC, prepare for call
-            */ #}
-       {#- /* set up pointers to input/output arguments */ #}
-       {%- for arg in func.c_args %}
-        {{ arg.cast_pointer }}
-       {%- endfor %}
-       {#- /* copy from in to out for arugments changed in-place */ #}
-       {%- for arg in func.inout_args %}
-        {{ arg.memcpy_if_needed | indent(8) }}
-       {%- endfor %}
-      {%- endif %} {#- end of gufunc/ufunc preparation #}
-        {{ func.erfa_call | indent(8) }}
-      {%- if func.signature %}
-       {#- /* for generalized ufunc, copy output from buffer if needed */ #}
-       {%- for arg in func.inout_or_out_args %}
-        {%- if arg.signature_shape != '()' %}
-        if (copy_{{ arg.name }}) {
-            {{ arg.copy_elements("from") }}
-        }
-        {%- endif %}
-       {%- endfor %}
-      {%- endif %}
+        {{ func.ufunc_loop_inner_loop_body | indent(8) }}
     }
     {%- if func.user_dtype == 'dt_eraLDBODY' %}
     if (copy_b) {
@@ -849,7 +762,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         1, {{ func.py_args|count }}, {{ func.ufunc_return|count }}, PyUFunc_None,
         "{{ func.pyname }}",
         "UFunc wrapper for {{ func.name }}",
-        0, {% if func.signature -%} "{{ func.signature }}" {%- else -%} NULL {%- endif -%});
+        0, {{ func.signature }});
     if (ufunc == NULL) {
         goto fail;
     }
@@ -859,7 +772,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         0, {{ func.py_args|count }}, {{ func.ufunc_return|count }}, PyUFunc_None,
         "{{ func.pyname }}",
         "UFunc wrapper for {{ func.name }}",
-        0, {% if func.signature -%} "{{ func.signature }}" {%- else -%} NULL {%- endif -%});
+        0, {{ func.signature }});
     if (ufunc == NULL) {
         goto fail;
     }

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -152,42 +152,7 @@ static inline void copy_to_eraLDBODY(char *ptr, npy_intp s, npy_intp n,
 static void ufunc_loop_{{ func.pyname }}(
     char **args, npy_intp const *dimensions, npy_intp const* steps, void* data)
 {
-  {#- /* index and length of loop */ #}
-    npy_intp i_o;
-    npy_intp n_o = *dimensions++;
-  {#- /*
-       * Pointers to each argument, required step size
-       */ #}
-  {#- /* normal input arguments */ #}
-  {%- for arg in func.in_args %}
-    char *{{ arg.name }} = *args++;
-    npy_intp s_{{ arg.name }} = *steps++;
-  {%- endfor -%}
-  {#- /* for in part of in-place arguments, we need a different name */ #}
-  {%- for arg in func.inout_args %}
-    char *{{ arg.name }}_in = *args++;
-    npy_intp s_{{ arg.name }}_in = *steps++;
-  {%- endfor -%}
-  {#- /* out part of input, and output arguments, including status */ #}
-  {%- for arg in func.ufunc_return %}
-    char *{{ arg.name }} = *args++;
-    npy_intp s_{{ arg.name }} = *steps++;
-  {%- endfor -%}
-  {#- /*
-       * Cast pointers and possible contiguous buffers (for gufuncs)
-       */ #}
-  {%- for arg in func.c_args %}
-   {%- if arg.signature_shape == '()' or arg.ctype == 'eraLDBODY'  %}
-    {{ arg.ctype }} (*_{{ arg.name }}){{ arg.cshape }};
-   {%- else %}
-    double b_{{ arg.name }}{{ arg.cshape }};
-    {{ arg.ctype }} (*_{{ arg.name }}){{ arg.cshape }} = &b_{{ arg.name }};
-   {%- endif %}
-  {%- endfor %}
-  {#- /* variables to hold status and return values */ #}
-  {%- if func.c_retval %}
-    {{ func.c_retval.ctype }} _{{ func.c_retval.name }};
-  {%- endif %}
+    {{ func.init_ufunc_loop_local_vars | indent(4) }}
   {#- /*
        * For GENERALIZED UFUNCS - inner loop steps, needs for copying.
        */ #}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -95,6 +95,13 @@ class Variable:
     def signature_shape(self) -> str:
         return "()"
 
+    def init_pointer_and_step_size(self, name_suffix: str = "") -> str:
+        name = self.name + name_suffix
+        return "\n".join([
+            f"char *{name} = *args++;",
+            f"npy_intp s_{name} = *steps++;",
+        ])
+
 
 class Argument(Variable):
     def __init__(self, definition: str) -> None:
@@ -179,6 +186,17 @@ class Argument(Variable):
             case "double", (3, 3):
                 return "(3, 3)"
         return super().signature_shape
+
+    @functools.cached_property
+    def cast_pointer_and_possible_contiguous_buffer(self) -> str:
+        return (
+            f"{self.ctype} (*_{self.name}){self.cshape};"
+            if self.signature_shape == "()" or self.ctype == "eraLDBODY"
+            else "\n".join([
+                f"double b_{self.name}{self.cshape};",
+                f"{self.ctype} (*_{self.name}){self.cshape} = &b_{self.name};",
+            ])
+        )
 
     def inner_loop_steps_and_copy(self, name_suffix: str = "") -> str | None:
         if self.signature_shape == "()":
@@ -404,6 +422,20 @@ class Function:
             else self.result_tuple.create()
         )
         lines.append(f"return {ret_val}")
+        return "\n".join(lines)
+
+    @functools.cached_property
+    def init_ufunc_loop_local_vars(self) -> str:
+        lines = [
+            "npy_intp i_o;",  # loop index
+            "npy_intp n_o = *dimensions++;",  # loop length
+            *[arg.init_pointer_and_step_size() for arg in self.in_args],
+            *[arg.init_pointer_and_step_size("_in") for arg in self.inout_args],
+            *[arg.init_pointer_and_step_size() for arg in self.ufunc_return],
+            *[arg.cast_pointer_and_possible_contiguous_buffer for arg in self.c_args],
+        ]
+        if self.c_retval:
+            lines.append(f"{self.c_retval.ctype} _{self.c_retval.name};")
         return "\n".join(lines)
 
     def inner_loop_steps_and_copies(self) -> str:

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -9,7 +9,8 @@ or dtypes for those structs.  They should be added manually in the template file
 
 import functools
 import re
-from collections.abc import Iterable
+from abc import ABC, abstractproperty
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Final, final
 
@@ -295,7 +296,7 @@ class ResultTuple:
         return f'{self.name} = namedtuple("{self.name}", "{self.arg_names}")'
 
 
-class Function:
+class Function(ABC):
     """
     A class representing a C function.
 
@@ -307,21 +308,18 @@ class Function:
         Directory with the file containing the function implementation.
     """
 
-    c_retval: Return | StatusCode | None = None
-
-    def __init__(self, name: str, source_path: Path) -> None:
+    def __init__(
+        self,
+        name: str,
+        doc: FunctionDoc,
+        args: Sequence[Argument],
+        c_retval: Return | StatusCode | None,
+    ) -> None:
         self.name: Final = name
         self.pyname: Final = name.removeprefix("era").lower()
+        self.doc: Final = doc
+        self.c_retval: Final = c_retval
 
-        file = source_path / f"{self.pyname}.c"
-        search = re.search(
-            rf"(\w+) {name} ?\((.+?)\).+?/\*(.+?)\*/", file.read_text(), re.DOTALL
-        )
-        if search is None:
-            raise RuntimeError(f"cannot find {name}() definition in {file}")
-
-        self.doc: Final = FunctionDoc(search.group(3), self.pyname)
-        args = [Argument(arg) for arg in re.findall("[^,]+", search.group(2))]
         self.in_args: Final = tuple(a for a in args if a.name in self.doc.input)
         self.inout_args: Final = tuple(a for a in args if a.name in self.doc.inout)
         self.out_args: Final = tuple(a for a in args if a.name in self.doc.output)
@@ -330,12 +328,30 @@ class Function:
         self.c_args: Final = (*self.py_args, *self.out_args)
         self.inout_or_out_args: Final = (*self.inout_args, *self.out_args)
 
+    @classmethod
+    def from_c_code(cls, name: str, source_path: Path) -> "Function":
+        pyname = name.removeprefix("era").lower()
+        file = source_path / f"{pyname}.c"
+        search = re.search(
+            rf"(\w+) {name} ?\((.+?)\).+?/\*(.+?)\*/", file.read_text(), re.DOTALL
+        )
+        if search is None:
+            raise RuntimeError(f"cannot find {name}() definition in {file}")
+
+        doc = FunctionDoc(search.group(3), pyname)
+        args = [Argument(arg) for arg in re.findall("[^,]+", search.group(2))]
+        c_retval = None
         if (ret := search.group(1)) != "void":
-            self.c_retval = (
-                StatusCode(ret, self.doc, name)
-                if ret == "int" and self.pyname not in ("tpors", "tporv")
+            c_retval = (
+                StatusCode(ret, doc, name)
+                if ret == "int" and pyname not in ("tpors", "tporv")
                 else Return(ret)
             )
+        return (
+            UFunc(name, doc, args, c_retval)
+            if all(arg.signature_shape == "()" for arg in args)
+            else GUFunc(name, doc, args, c_retval)
+        )
 
     @functools.cached_property
     def result_tuple(self) -> ResultTuple | None:
@@ -378,18 +394,9 @@ class Function:
 
         return user_dtype
 
-    @property
-    def signature(self) -> str | None:
+    @abstractproperty
+    def signature(self) -> str:
         """Possible signature, if this function should be a gufunc."""
-        return (
-            (
-                ",".join(arg.signature_shape for arg in self.py_args)
-                + "->"
-                + ",".join(arg.signature_shape for arg in self.ufunc_return)
-            )
-            if any(arg.signature_shape != "()" for arg in self.c_args)
-            else None
-        )
 
     def generate_python_body(self) -> str:
         ufunc_name = f"ufunc.{self.pyname}"
@@ -438,12 +445,6 @@ class Function:
             lines.append(f"{self.c_retval.ctype} _{self.c_retval.name};")
         return "\n".join(lines)
 
-    def inner_loop_steps_and_copies(self) -> str:
-        in_only = [a.inner_loop_steps_and_copy() for a in self.in_args]
-        inout = [a.inner_loop_steps_and_copy("_in") for a in self.inout_args]
-        out = [a.inner_loop_steps_and_copy() for a in self.inout_or_out_args]
-        return "\n".join(filter(None, in_only + inout + out))
-
     @functools.cached_property
     def increment_arg_pointers(self) -> str:
         return ", ".join(
@@ -451,17 +452,117 @@ class Function:
             + [f"{arg.name}_in += s_{arg.name}_in" for arg in self.inout_args],
         )
 
+    @abstractproperty
+    def prepare_for_call(self) -> str:
+        pass
+
     @functools.cached_property
-    def erfa_call(self) -> str:
+    def ufunc_loop_inner_loop_body(self) -> str:
+        lines = [self.prepare_for_call]
         call = _assemble_func_call(self.name, [a.name_for_call for a in self.c_args])
+        if retval := self.c_retval:
+            lines.extend([
+                f"_{retval.name} = {call};",
+                f"*(({retval.ctype} *){retval.name}) = _{retval.name};",
+            ])
+        else:
+            lines.append(call + ";")
+        return "\n".join(lines)
+
+
+class UFunc(Function):
+    @functools.cached_property
+    def signature(self) -> str:
+        return "NULL"
+
+    @functools.cached_property
+    def prepare_for_call(self) -> str:
+        return "\n".join([
+            *[arg.cast_pointer for arg in self.c_args],
+            *[arg.memcpy_if_needed for arg in self.inout_args],
+        ])
+
+
+class GUFunc(Function):
+    @functools.cached_property
+    def signature(self) -> str:
         return (
-            (
-                f"_{c_retval.name} = {call};\n"
-                f"*(({c_retval.ctype} *){c_retval.name}) = _{c_retval.name};"
-            )
-            if (c_retval := self.c_retval)
-            else f"{call};"
+            f'"{",".join(arg.signature_shape for arg in self.py_args)}'
+            f'->{",".join(arg.signature_shape for arg in self.ufunc_return)}"'
         )
+
+    @functools.cached_property
+    def init_ufunc_loop_local_vars(self) -> str:
+        lines = [super().init_ufunc_loop_local_vars]
+        lines.extend([  # only LDBODY has non-fixed dimension; it is always first
+            "int nb = (int)dimensions[0];  /* Refuse to worry about INT_MAX */"
+            for arg in self.in_args
+            if arg.ctype == "eraLDBODY"
+        ])
+        in_only = [a.inner_loop_steps_and_copy() for a in self.in_args]
+        inout = [a.inner_loop_steps_and_copy("_in") for a in self.inout_args]
+        out = [a.inner_loop_steps_and_copy() for a in self.inout_or_out_args]
+        lines.extend(filter(None, in_only + inout + out))
+        if self.user_dtype == "dt_eraLDBODY":
+            # if needed, allocate memory for contiguous eraLDBODY copies
+            lines.extend([
+                "if (copy_b) {",
+                "    // Note that we can't use PyArray_malloc here as it is an alias to PyMem_RawMalloc",
+                "    // which is not available in the Python limited API",
+                "    _b = malloc(nb * sizeof(eraLDBODY));",
+                "    if (_b == NULL) {",
+                "        PyErr_NoMemory();",
+                "        return;",
+                "    }",
+                "}",
+                "else {",  # just to keep compiler happy
+                "    _b = NULL;",
+                "}",
+            ])
+        return "\n".join(lines)
+
+    @functools.cached_property
+    def prepare_for_call(self) -> str:
+        lines = []
+        for arg in self.in_args:  # copy input arguments to buffer if needed
+            if arg.signature_shape == "()":
+                lines.append(arg.cast_pointer)
+            else:
+                lines.extend([
+                    arg.cast_pointer_if_needed,
+                    "else {",
+                    f"    {arg.copy_elements('to')}",
+                    "}",
+                ])
+        # for inout arguments, set up output first, and then copy to it if needed
+        for arg in self.inout_args:
+            lines.extend(
+                [arg.cast_pointer, arg.memcpy_if_needed]
+                if arg.signature_shape == "()"
+                else [
+                    arg.cast_pointer_if_needed,
+                    f"if (copy_{arg.name}_in || {arg.name} != {arg.name}_in) {{",
+                    f"    {arg.copy_elements('to', '_in')}",
+                    "}",
+                ]
+            )
+        lines.extend([  # set up gufunc outputs
+            a.cast_pointer if a.signature_shape == "()" else a.cast_pointer_if_needed
+            for a in self.out_args
+        ])
+        return "\n".join(lines)
+
+    @functools.cached_property
+    def ufunc_loop_inner_loop_body(self) -> str:
+        lines = [super().ufunc_loop_inner_loop_body]
+        for arg in self.inout_or_out_args:
+            if arg.signature_shape != "()":
+                lines.extend([
+                    f"if (copy_{arg.name}) {{",
+                    f"    {arg.copy_elements('from')}",
+                    "}",
+                ])
+        return "\n".join(lines)
 
 
 class Constant:
@@ -646,7 +747,7 @@ def main(srcdir: Path, templateloc: Path) -> None:
     env = Environment(loader=FileSystemLoader(templateloc))
 
     funcs = [
-        Function(name, srcdir)
+        Function.from_c_code(name, srcdir)
         for name in re.findall(
             r"\w+ (\w+)\(.*?\);", (srcdir / "erfa.h").read_text(), flags=re.DOTALL
         )


### PR DESCRIPTION
Some ERFA function wrappers are normal ufuncs, others are generalized ufuncs. On current `main` the `erfa/ufunc.c` template has to repeatedly check a function's `signature` property to decide which of the two cases it is dealing with and what the generated code should be. This PR introduces the `UFunc` and `GUFunc` classes to `erfa_generator.py`, which are both subclasses of `Function` (which is now abstract). The new `Function.from_c_code()` class method determines whether an ERFA function should be wrapped by a normal or a generalized ufunc and returns a `UFunc` or a `GUFunc` instance accordingly. The template now never has to check which case it is dealing with, it can call the same properties either way. Overall this simplifies the template's implementation at the cost of making `erfa_generator.py` more complicated, but that is a good tradeoff because Python code can be checked with tools such as Ruff or Mypy and there is better IDE support.

There are no differences in the code `erfa_generator` produces.