### PR TITLE
Move some gufunc-specific code from `ufunc.c` template to `GUFunc` class

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -152,19 +152,7 @@ static inline void copy_to_eraLDBODY(char *ptr, npy_intp s, npy_intp n,
 static void ufunc_loop_{{ func.pyname }}(
     char **args, npy_intp const *dimensions, npy_intp const* steps, void* data)
 {
-    {{ func.init_ufunc_loop_local_vars | indent(4) }}
-  {#- /*
-       * Actual inner loop, increasing all pointers by their steps
-       */ #}
-    for (i_o = 0; i_o < n_o;
-         i_o++, {{ func.increment_arg_pointers }}) {
-        {{ func.ufunc_loop_inner_loop_body | indent(8) }}
-    }
-    {%- if func.user_dtype == 'dt_eraLDBODY' %}
-    if (copy_b) {
-        free(_b);
-    }
-    {%- endif %}
+    {{ func.ufunc_loop_body | indent(4) }}
 }
 
 {%- endfor %}

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -9,6 +9,7 @@ or dtypes for those structs.  They should be added manually in the template file
 
 import functools
 import re
+import textwrap
 from abc import ABC, abstractproperty
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -446,11 +447,18 @@ class Function(ABC):
         return "\n".join(lines)
 
     @functools.cached_property
-    def increment_arg_pointers(self) -> str:
-        return ", ".join(
+    def ufunc_loop_body(self) -> str:
+        arg_pointer_incrementation = ", ".join(
             [f"{arg.name} += s_{arg.name}" for arg in self.in_args + self.ufunc_return]
             + [f"{arg.name}_in += s_{arg.name}_in" for arg in self.inout_args],
         )
+        return "\n".join([
+            self.init_ufunc_loop_local_vars,
+            "for (i_o = 0; i_o < n_o;",
+            f"     i_o++, {arg_pointer_incrementation}) {{",
+            textwrap.indent(self.ufunc_loop_inner_loop_body, 4 * " "),
+            "}",
+        ])
 
     @abstractproperty
     def prepare_for_call(self) -> str:
@@ -490,6 +498,17 @@ class GUFunc(Function):
             f'"{",".join(arg.signature_shape for arg in self.py_args)}'
             f'->{",".join(arg.signature_shape for arg in self.ufunc_return)}"'
         )
+
+    @functools.cached_property
+    def ufunc_loop_body(self) -> str:
+        lines = [super().ufunc_loop_body]
+        if self.user_dtype == "dt_eraLDBODY":
+            lines.extend([
+                "if (copy_b) {",
+                "    free(_b);",
+                "}",
+            ])
+        return "\n".join(lines)
 
     @functools.cached_property
     def init_ufunc_loop_local_vars(self) -> str:


### PR DESCRIPTION
When I implemented the `GUFunc` class in 489b9a87bccfef8e22a7a1040c9a06152f3e6ce6 I made a simplifying assumption that code which is specific to gufuncs could be found by grepping for `func.signature` in the `ufunc.c` template, but now I've found some gufunc code that did not mention `func.signature` at all. Such code should be implemented in the `GUFunc` class, not in any template.