### PR TITLE
Fix an 'int-in-bool-context' mistake

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -728,7 +728,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         PyDict_SetItemString(d, "dt_type", (PyObject *)dt_type) < 0 ||
         PyDict_SetItemString(d, "dt_eraLDBODY", (PyObject *)dt_eraLDBODY) < 0 ||
         PyDict_SetItemString(d, "dt_eraASTROM", (PyObject *)dt_eraASTROM) < 0 ||
-        PyDict_SetItemString(d, "dt_eraLEAPSECOND", (PyObject *)dt_eraLEAPSECOND) << 0) {
+        PyDict_SetItemString(d, "dt_eraLEAPSECOND", (PyObject *)dt_eraLEAPSECOND) < 0) {
         goto fail;
     }
     /*


### PR DESCRIPTION
On current `main` running `uv pip install --verbose -e .` reports (among other things)
```
DEBUG erfa/ufunc.c:10450:83: warning: ‘<<’ in boolean context, did you mean ‘<’? [-Wint-in-bool-context]
DEBUG 10450 |         PyDict_SetItemString(d, "dt_eraLEAPSECOND", (PyObject *)dt_eraLEAPSECOND) << 0) {
DEBUG       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```