### PR TITLE
Allow installing development version sdist tarball with `setuptools-scm>=10`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,14 @@ def guess_next_dev(version: ScmVersion) -> str:
     version_string = str(version.tag)
     erfa_version = git.parse(LIBERFADIR, config=Configuration(root=LIBERFADIR))
     if erfa_version is None:
-        # Must be installing from an sdist. Any warnings should have been dealt with
-        # when the sdist was built, so we can assume version_string is correct.
-        return version_string
+        # Must be installing from an sdist so we cannot check the ERFA tag. We will
+        # assume it is consistent with the pyerfa version tag, otherwise there was
+        # a problem when the sdist was built that we cannot fix at this point.
+        return (
+            version_string
+            if version.exact
+            else version.format_next_version(guess_next_version)
+        )
     if not erfa_version.exact:
         warn(f"liberfa/erfa not at a tagged release, but at {erfa_version}")
     erfa_tag = erfa_version.format_with("{tag}")


### PR DESCRIPTION
Installing an sdist with `setuptools-scm>=10` includes calling `guess_next_dev()` in `setup.py`, which tries to ensure (among other things) that the `pyerfa` and ERFA versions are consistent, but an sdist does not contain enough information about ERFA versions to do that. #276 attempted to solve the problem, but the changes there require extracting files from the sdist tarball and even then the installation of an sdist of a development version ends up reporting a wrong version tag. With this PR it is possible to install `pyerfa` development versions directly from an sdist tarball both with `setuptools-scm<10` and `>=10`.

Closes #289