### PR TITLE
Store ERFA doc comments without leading whitespace

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -135,7 +135,7 @@ STATUS_CODES["{{ func.pyname }}"] = {{ func.c_retval.to_python() }}
 
 def {{ func.pyname }}({{ func.py_args|map(attribute='name')|join(', ') }}):
     """
-    {{ func.doc.first_sentence | indent(2)}}
+    {{ func.doc.first_sentence | indent(4)}}
     {%- if func.py_args %}
 
     Parameters
@@ -162,7 +162,7 @@ def {{ func.pyname }}({{ func.py_args|map(attribute='name')|join(', ') }}):
     | map(attribute='name')|join(', ') }} in-place.
     {%- endif %} The ERFA documentation is::
 
-{{ func.doc.doc | indent(6, true) }}
+        {{ func.doc.doc | indent(8) }}
     """
     {{ func.generate_python_body() | indent(4) }}
 

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -29,10 +29,12 @@ class FunctionDoc:
             doc = doc.removeprefix("+")
         elif pyname == "aticqn":
             doc = doc.replace("\n* ", "\n** ", 2).replace("\n*\n", "\n**\n", 1)
-        self.doc: Final = doc.replace("\n**", "\n").removeprefix("\n")
+        self.doc: Final = re.sub(
+            r"^\*\* {,2}", "", doc.removeprefix("\n"), flags=re.MULTILINE
+        )
 
         get_arg_doc_list = functools.partial(
-            self._get_arg_doc_list, n_spaces=4 if pyname in ("ab", "refco") else 5
+            self._get_arg_doc_list, n_spaces=2 if pyname in ("ab", "refco") else 3
         )
         self.input: Final = get_arg_doc_list("Given.*?\n(.+?)\n\n")
         self.inout: Final = get_arg_doc_list("Given and returned:\n(.+?)\n\n")
@@ -67,7 +69,7 @@ class FunctionDoc:
 
     @property
     def first_sentence(self) -> str:
-        if m := re.search(r"[- ]+\n\n  (.+?\.)\s", self.doc, re.DOTALL):
+        if m := re.search(r"[- ]+\n\n(.+?\.)\s", self.doc, re.DOTALL):
             return m.group(1)
         raise RuntimeError(
             f"cannot find the first sentence of {self.pyname} doc comment"


### PR DESCRIPTION
The lines of ERFA doc comments start with "**  " (or just "**" if they are empty). On current `main` when a `FunctionDoc` extracts a doc comment it removes the leading "**" from each line, but not the "  ". This is annoying because the doc comments are inserted to the Python wrapper docstrings in which everything else is aligned using steps of 4 spaces. With this PR the common leading whitespace is removed too, which allows doc comments to be indented in the docstrings by a multiple of 4 spaces like everything else.