### PR TITLE
Avoid changing `ERFA_SRS` comment

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -109,7 +109,7 @@ dt_bytes1 = np.dtype("S1")
 
 {% for constant in constants %}
 {{ constant.name }} = {{ constant.value }}
-"""{{ constant.doc|join(' ')|wordwrap() }}"""
+"""{{ constant.doc }}"""
 {%- endfor %}
 
 

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -660,7 +660,7 @@ class GUFunc(Function):
 
 class Constant:
 
-    def __init__(self, name: str, value: str, doc: list[str]) -> None:
+    def __init__(self, name: str, value: str, doc: str) -> None:
         self.name = name.replace("ERFA_", "")
         self.value = value.replace("ERFA_", "")
         self.doc = doc
@@ -856,7 +856,7 @@ def main(srcdir: Path, templateloc: Path) -> None:
 
     constants: list[Constant] = []
     for chunk in (srcdir / "erfam.h").read_text().split("\n\n"):
-        doc = re.findall(r"/\* (.+?) \*/\n", chunk, flags=re.DOTALL)
+        doc = "\n".join(re.findall(r"/\* (.+?) \*/\n", chunk, flags=re.DOTALL))
         constants.extend(
             Constant(name, value, doc)
             for name, value in re.findall(


### PR DESCRIPTION
The ERFA constants are accompanied by comments that are also written next to the definitions of corresponding constants in `erfa/core.py`. Most of the comments fit on a single line, but the comment for `ERFA_SRS` takes up two lines. Current `main` changes where the line break is, but there is no good reason for doing that. The full difference between the `erfa/core.py` files generated by current `main` and this PR is:
```diff
435,436c435,436
< """Schwarzschild radius of the Sun (au) = 2 * 1.32712440041e20 / (2.99792458e8)^2
< / 1.49597870700e11"""
---
> """Schwarzschild radius of the Sun (au)
> = 2 * 1.32712440041e20 / (2.99792458e8)^2 / 1.49597870700e11"""
```