### PR TITLE
Drop `jinja2` as a build dependency

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -141,7 +141,7 @@ jobs:
         python-version: '3.10'
     - name: Install build-time dependencies
       run: |
-        python -m pip install --upgrade wheel setuptools setuptools_scm jinja2 'numpy<2.0'
+        python -m pip install --upgrade wheel setuptools setuptools_scm 'numpy<2.0'
     - run: python -m pip list
     - name: Build
       # using --no-build-isolation allows us to skip pass build-system metadata

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       # the build isolation and explicitly install the latest developer version of numpy as well as
       # the latest stable versions of all other build-time dependencies.
       env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm wheel jinja2 numpy') || '' }}'
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm wheel numpy') || '' }}'
         CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
 
       test_extras: test

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,7 @@ called with scalar or array inputs.
 
 The project is a split of ``astropy._erfa`` module, developed in the
 context of Astropy_ project, into a standalone package.  It contains
-the ERFA_ C source code as a git submodule.  The wrapping is done
-with help of the Jinja2_ template engine.
+the ERFA_ C source code as a git submodule.
 
 If you use this package in your research, please cita it via DOI
 `10.5281/zenodo.3940699 <https://doi.org/10.5281/zenodo.3940699>`_.
@@ -116,7 +115,6 @@ PyERFA is licensed under a 3-clause BSD style license - see the
 .. _Numpy: https://numpy.org/
 .. _Astropy: https://www.astropy.org
 .. _PyPI: https://pypi.org/project/pyerfa/
-.. _Jinja2: https://palletsprojects.com/p/jinja/
 .. |PyPI Status| image:: https://img.shields.io/pypi/v/pyerfa.svg
     :target: https://pypi.python.org/pypi/pyerfa
     :alt: PyPI Status

--- a/erfa/tests/test_ufunc.py.templ
+++ b/erfa/tests/test_ufunc.py.templ
@@ -29,14 +29,6 @@ if not erfa.__version__.startswith(erfa.version.erfa_version):
 
 
 # <--------------------------Actual test-wrapping code------------------------>
-{%- for test in test_funcs %}
 
 
-def test_{{ test.func.pyname }}():
-    {%- for line in test.to_python() %}
-    {{ line }}
-    {%- endfor %}
-
-
-{%- endfor %}
-{# done! (note: this comment also ensures final new line!) #}
+$test_functions

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -16,8 +16,6 @@ from pathlib import Path
 from string import Template
 from typing import Final, final
 
-from jinja2 import Environment, FileSystemLoader
-
 DEFAULT_ERFA_LOC = Path(__file__).with_name("liberfa") / "erfa" / "src"
 DEFAULT_TEMPLATE_LOC = Path(__file__).with_name("erfa")
 
@@ -916,10 +914,18 @@ def main(srcdir: Path, templateloc: Path) -> None:
         TestFunction, t_erfa_c=(srcdir / "t_erfa_c.c").read_text()
     )
     (testloc / testfn).write_text(
-        Environment(loader=FileSystemLoader(testloc))
-        .get_template(testfn + ".templ")
-        .render(
-            test_funcs=sorted(map(create_test_funcs, funcs), key=lambda f: f.func.name)
+        Template((testloc / f"{testfn}.templ").read_text()).substitute(
+            test_functions="\n\n\n".join([
+                _indent(
+                    "\n".join([
+                        f"def test_{test_func.func.pyname}():",
+                        *test_func.to_python(),
+                    ])
+                )
+                for test_func in sorted(
+                    map(create_test_funcs, funcs), key=lambda f: f.func.name
+                )
+            ])
         )
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=77.0.0",
     "setuptools_scm>=8.0.0",
-    "jinja2>=2.10.3",
     "numpy>=2.0.0rc1",
 ]
 build-backend = 'setuptools.build_meta'
@@ -38,7 +37,6 @@ docs = ["sphinx-astropy>=1.3"]
 
 [dependency-groups]
 typing = [
-    "jinja2>=2.10.3",
     "mypy>=1.20.1",
     # Some code was moved from setuptools-scm 10 to a separate vcs-versioning library,
     # but vcs-versioning<= 1.1.1 lacks the py.typed marker file (accidentally).


### PR DESCRIPTION
In this PR the templates that were rendered with `jinja2` are now rendered using only the Python standard library and `erfa_generator.py` (`erfa/tests/test_ufunc.py.templ` is updated in this PR, others have already been updated earlier). This has required moving all conditional branching and loops from the templates to `erfa_generator.py`, but that was a good tradeoff because Python has better IDE support and the code in `erfa_generator.py` can be checked with tools such as mypy.