### PR TITLE
Remove an obsolete workaround for GCC < 10

### DIFF
--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -27,19 +27,6 @@ that do not support it (e.g., 3.13t)
 #define PyDataType_ELSIZE(descr) ((descr)->elsize)
 #endif
 
-// On gcc<10 we can run into the following:
-//
-//   error: dereferencing pointer to incomplete type 'PyTypeObject'
-//
-// As mentioned in https://github.com/numpy/numpy/issues/16970,
-// the workaround is to define a fake _typeobject struct.
-
-#if (defined Py_LIMITED_API) && !(defined PYPY_VERSION)
-typedef struct _typeobject {
-    int dummy;
-};
-#endif
-
 #define MODULE_DOCSTRING \
     "Ufunc wrappers of the ERFA routines.\n\n" \
     "These ufuncs vectorize the ERFA functions assuming structured dtypes\n" \


### PR DESCRIPTION
Running `uv pip install --verbose --editable .` reports (among other things)
```
DEBUG erfa/ufunc.c:40:1: warning: useless storage class specifier in empty declaration
DEBUG    40 | };
DEBUG       | ^
```
The code that causes this warning is a workaround for a bug in GCC < 10. [Versions of GCC that do not require this workaround became available more than 6 years ago](https://gcc.gnu.org/releases.html), so the simplest way to avoid the warning is to remove the offending code.