### PR TITLE
Start enforcing the Ruff PGH ruleset

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import time
 from datetime import datetime
 
 try:
-    from sphinx_astropy.conf.v1 import *  # noqa
+    from sphinx_astropy.conf.v1 import *  # noqa: F403
     from sphinx_astropy.conf.v1 import exclude_patterns
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to be installed')

--- a/erfa/__init__.py
+++ b/erfa/__init__.py
@@ -2,8 +2,18 @@
 
 # Import version first, as this gives a more useful error message
 # if a system liberfa is too old.
-from .version import version as __version__  # noqa
-from .core import *  # noqa
-from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND,  # noqa
-                    dt_pv, dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
-from . import leap_seconds  # noqa
+from .version import version as __version__  # noqa: I001
+
+from .core import *
+from .ufunc import (
+    dt_eraASTROM,
+    dt_eraLDBODY,
+    dt_eraLEAPSECOND,
+    dt_pv,
+    dt_sign,
+    dt_type,
+    dt_ymdf,
+    dt_hmsf,
+    dt_dmsf,
+)
+from . import leap_seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ extend-select = [
     "ARG",
     "ERA",
     "I",
+    "PGH",
     "PLC",
     "PLE",
     "PT",
@@ -91,6 +92,10 @@ extend-select = [
     "UP",
 ]
 [tool.ruff.lint.extend-per-file-ignores]
+"__init__.py" = [
+    "F401",  # unused-import
+    "F403",  # undefined-local-with-import-star
+]
 "test_*.py" = ["S101"]
 
 [tool.mypy]


### PR DESCRIPTION
In current `main` there are a few violations of [PGH004 (blanket-noqa)](https://docs.astral.sh/ruff/rules/blanket-noqa/). I added global configuration to ignore [F401 (unused-import)](https://docs.astral.sh/ruff/rules/unused-import/) and [F403 (undefined-local-with-import-star)](https://docs.astral.sh/ruff/rules/undefined-local-with-import-star/) in `__init__.py` files because I don't think these rules have to be enforced in `__init__.py` files in general. The other blanket noqas now suppress a single rule.