### PR TITLE
Update OpenAstronomy GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
   build_and_publish:
 
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@e5af21e4ae37af089a73bb032e10b78b0e746174 # v3.0.1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1  # v3.0.2
     if: (github.repository == 'liberfa/pyerfa')
     with:
 


### PR DESCRIPTION
The `build_and_publish` CI job has been failing for a few days now. Updating the OpenAstronomy workflow solves the problem.