### PR TITLE
Change deciding if `setup.py` should run `erfa_generator`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ from setuptools_scm.version import guess_next_version
 
 LIBERFADIR = Path("liberfa", "erfa")
 ERFA_SRC = LIBERFADIR / "src"
-GEN_FILES = [Path("erfa", "core.py"), Path("erfa", "ufunc.c")]
 
 
 # build with Py_LIMITED_API unless in freethreading build (which does not currently
@@ -88,21 +87,15 @@ def guess_next_dev(version: ScmVersion) -> str:
     )
 
 
-gen_files_exist = all(path.is_file() for path in GEN_FILES)
-if ERFA_SRC.is_dir():
-    # assume that 'erfaversion.c' is updated at each release at least
-    src_mtime = (ERFA_SRC / "erfaversion.c").stat().st_mtime
-elif not gen_files_exist:
-    raise RuntimeError(
-        'Missing "liberfa" source files, unable to generate '
-        '"erfa/ufunc.c" and "erfa/core.py". '
-        "Please check your source tree. "
-        'Maybe "git submodule update" could help.'
-    )
-
-if not gen_files_exist or any(fn.stat().st_mtime < src_mtime for fn in GEN_FILES):
+if Path(".git").is_dir():  # don't run erfa_generator if building from an sdist
     print('Run "erfa_generator.py"')
-    subprocess.run([sys.executable, "erfa_generator.py"], check=True)
+    try:
+        subprocess.run([sys.executable, "erfa_generator.py"], check=True)
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            "unable to generate pyerfa files. Please check your source tree. "
+            'Maybe "git submodule update" could help.'
+        ) from err
 
 sources = [Path("erfa", "ufunc.c")]
 include_dirs = [np.get_include()]


### PR DESCRIPTION
`setup.py` tries to avoid running `erfa_generator` if it does not have to, but the criteria for deciding are complicated and not without problems. For example, the code checks if the generated files are older than the ERFA C source files, but completely ignores the age of `erfa_generator.py` itself. In this PR `setup.py` simply checks for the presence of the `.git/` directory to see if `pyerfa` is being built in a repository or from an sdist. Building in a repository always runs `erfa_generator`, building from an sdist never does. If `erfa_generator` is called but fails then the error message suggests running `git submodule update` because that solves what should be the most common reason for failure.