### PR TITLE
Ignore pre-existing ERFA `config.h` when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ from setuptools_scm.version import guess_next_version
 
 LIBERFADIR = Path("liberfa", "erfa")
 ERFA_SRC = LIBERFADIR / "src"
+BUILDING_FROM_SDIST = not Path(".git").is_dir()
 
 
 # build with Py_LIMITED_API unless in freethreading build (which does not currently
@@ -87,7 +88,7 @@ def guess_next_dev(version: ScmVersion) -> str:
     )
 
 
-if Path(".git").is_dir():  # don't run erfa_generator if building from an sdist
+if not BUILDING_FROM_SDIST:
     print('Run "erfa_generator.py"')
     try:
         subprocess.run([sys.executable, "erfa_generator.py"], check=True)
@@ -110,25 +111,23 @@ else:
         if file.suffix == ".c" and not file.name.startswith("t_")
     )
     # liberfa configuration
-    config_h = LIBERFADIR / "config.h"
-    if not config_h.exists():
+    if not BUILDING_FROM_SDIST:
         print("Configure liberfa")
         try:
-            if not (LIBERFADIR / "configure").exists():
-                subprocess.run(["./bootstrap.sh"], check=True, cwd=LIBERFADIR)
-            subprocess.run(["./configure"], check=True, cwd=LIBERFADIR)
-        except (subprocess.SubprocessError, OSError) as exc:
-            warn(f"unable to configure liberfa: {exc}")
-
-        if not config_h.exists():
-            if version_definitions := "\n".join(
-                f"#define {name} {value!r}".replace("'", '"')
-                for name, value in get_liberfa_versions()
-            ):
-                print('Configure liberfa ("configure.ac" scan)')
-                config_h.write_text(version_definitions)
-            else:
-                raise RuntimeError("unable to get liberfa version")
+            subprocess.run(["./bootstrap.sh"], check=True, cwd=LIBERFADIR)
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
+            warn(f"{err}\nMaybe installing autoconf, automake and libtool could help")
+    try:
+        subprocess.run(["./configure"], check=True, cwd=LIBERFADIR)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        if version_definitions := "\n".join(
+            f"#define {name} {value!r}".replace("'", '"')
+            for name, value in get_liberfa_versions()
+        ):
+            print('Configure liberfa ("configure.ac" scan)')
+            (LIBERFADIR / "config.h").write_text(version_definitions)
+        else:
+            raise RuntimeError("unable to get liberfa version")
     include_dirs.extend(map(str, [ERFA_SRC, LIBERFADIR]))
     define_macros.append(("HAVE_CONFIG_H", "1"))
 


### PR DESCRIPTION
On current `main` there is quite complicated code in `setup.py` to decide if and how to generate ERFA's `config.h`, but I don't think that code is behaving as it should. One problem is that `config.h` is not regenerated if it is already present, so if the `liberfa` submodule is ever updated then `pyerfa` will keep using the outdated `config.h`. Another problem is that `config.h` can be generated in two different ways. The preferred way is to run ERFA's `configure` script, but that has to be generated by running ERFA's `bootstrap.sh`, which requires additional C tooling (`autoconf`, `automake`, `libtool`). Because that tooling might not be available then `setup.py` can also directly generate a minimal `config.h` itself. Once the minimal file has been generated `pyerfa` will keep using it even if the C tooling is installed and generating the full file becomes possible. Both problems are further worsened because `config.h` is in the `liberfa` submodule `.gitignore`, so `git status` does not reveal its presence.

In this PR a pre-existing `config.h` is always ignored. Development installs try to generate the ERFA `configure` script by running ERFA's `bootstrap.sh`, but because `configure` should be included in an sdist tarball then installing from an sdist tries to use the existing `configure` as is. If anything goes wrong then `setup.py` still directly generates a minimal `config.h`.

One thing that worries me is that `setup.py` quite closely follows the intended ERFA build procedure from before it switched to using meson. I don't understand why `pyerfa` did not switch to meson when ERFA did.