### PR TITLE
Manual monthly `pre-commit` update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import time
 from datetime import datetime
 
 try:
-    from sphinx_astropy.conf.v1 import *  # noqa: F403
+    from sphinx_astropy.conf.v1 import *
     from sphinx_astropy.conf.v1 import exclude_patterns
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to be installed')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,10 +91,14 @@ extend-select = [
     "SIM",
     "UP",
 ]
+ignore = [
+    "BLE001",  # temporary
+    "DTZ",  # temporary
+    "S110",  # temporary
+]
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = [
     "F401",  # unused-import
-    "F403",  # undefined-local-with-import-star
 ]
 "test_*.py" = ["S101"]
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ if not BUILDING_FROM_SDIST:
 sources = [Path("erfa", "ufunc.c")]
 include_dirs = [np.get_include()]
 libraries = []
-if int(os.environ.get("PYERFA_USE_SYSTEM_LIBERFA", 0)):
+if int(os.environ.get("PYERFA_USE_SYSTEM_LIBERFA", "0")):
     print("Using system liberfa")
     libraries.append("erfa")
 else:


### PR DESCRIPTION
The automatic monthly `pre-commit` update (#308) failed because [Ruff 0.16 changed which lint rules are enabled by default](https://astral.sh/blog/ruff-v0.16.0#better-default-rule-set). I added a few (temporary) ignores to the Ruff configuration so that `pre-commit` checks could succeed.

Closes #308