### PR TITLE
Do not install the `wheel` package in CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -141,7 +141,7 @@ jobs:
         python-version: '3.10'
     - name: Install build-time dependencies
       run: |
-        python -m pip install --upgrade wheel setuptools setuptools_scm 'numpy<2.0'
+        python -m pip install --upgrade setuptools setuptools_scm 'numpy<2.0'
     - run: python -m pip list
     - name: Build
       # using --no-build-isolation allows us to skip pass build-system metadata

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       # the build isolation and explicitly install the latest developer version of numpy as well as
       # the latest stable versions of all other build-time dependencies.
       env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm wheel numpy') || '' }}'
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm numpy') || '' }}'
         CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
 
       test_extras: test


### PR DESCRIPTION
Explicitly installing `wheel` has not been needed since afcfaf6fa6b024d29037ab34b426153a6c1d0daa.