### PR TITLE
Inline two methods in `erfa_generator`

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -98,14 +98,6 @@ class Variable:
     def signature_shape(self) -> str:
         return "()"
 
-    def init_pointer_and_step_size(self, name_suffix: str = "") -> str:
-        name = self.name + name_suffix
-        return "\n".join([
-            f"char *{name} = *args++;",
-            f"npy_intp s_{name} = *steps++;",
-        ])
-
-
 class Argument(Variable):
     def __init__(self, definition: str) -> None:
         ctype, ptr_name_arr = definition.strip().rsplit(" ", 1)
@@ -189,17 +181,6 @@ class Argument(Variable):
             case "double", (3, 3):
                 return "(3, 3)"
         return super().signature_shape
-
-    @functools.cached_property
-    def cast_pointer_and_possible_contiguous_buffer(self) -> str:
-        return (
-            f"{self.ctype} (*_{self.name}){self.cshape};"
-            if self.signature_shape == "()" or self.ctype == "eraLDBODY"
-            else "\n".join([
-                f"double b_{self.name}{self.cshape};",
-                f"{self.ctype} (*_{self.name}){self.cshape} = &b_{self.name};",
-            ])
-        )
 
     def inner_loop_steps_and_copy(self, name_suffix: str = "") -> str | None:
         if self.signature_shape == "()":
@@ -429,12 +410,19 @@ class Function(ABC):
 
     @functools.cached_property
     def init_ufunc_loop_local_vars(self) -> str:
-        lines = [
-            *[arg.init_pointer_and_step_size() for arg in self.in_args],
-            *[arg.init_pointer_and_step_size("_in") for arg in self.inout_args],
-            *[arg.init_pointer_and_step_size() for arg in self.ufunc_return],
-            *[arg.cast_pointer_and_possible_contiguous_buffer for arg in self.c_args],
-        ]
+        lines: list[str] = []
+        for f in ("char *{} = *args++;".format, "npy_intp s_{} = *steps++;".format):
+            lines.extend(f(arg.name) for arg in self.in_args)
+            lines.extend(f(arg.name + "_in") for arg in self.inout_args)
+            lines.extend(f(arg.name) for arg in self.ufunc_return)
+        for arg in self.c_args:
+            if arg.signature_shape == "()" or arg.ctype == "eraLDBODY":
+                lines.append(f"{arg.ctype} (*_{arg.name}){arg.cshape};")
+            else:
+                lines.extend([
+                    f"double b_{arg.name}{arg.cshape};",
+                    f"{arg.ctype} (*_{arg.name}){arg.cshape} = &b_{arg.name};",
+                ])
         if self.c_retval:
             lines.append(f"{self.c_retval.ctype} _{self.c_retval.name};")
         return "\n".join(lines)


### PR DESCRIPTION
When I was working on migrating away from using `jinja` templates I had to be sure that any code I move from a template to `erfa_generator` can still be easily called from the template. Now that we don't use `jinja` anymore that constraint is no longer relevant and `erfa_generator` can be simplified. In this PR I am inlining the `Variable.init_pointer_and_step_size()` method and the `Argument.cast_pointer_and_possible_contiguous_buffer` property, which are both only called in `Function.init_ufunc_loop_local_vars()`, the implementation of which can be further simplified if some statements in the generated `erfa/ufunc.c` are allowed to be re-ordered. For example, with the files generated by `erfa_generator` on current `main`
```
$ sed -n 246,251p erfa/ufunc.c
    char *epj = *args++;
    npy_intp s_epj = *steps++;
    char *djm0 = *args++;
    npy_intp s_djm0 = *steps++;
    char *djm = *args++;
    npy_intp s_djm = *steps++;
```
but with this PR
```
$ sed -n 246,251p erfa/ufunc.c
    char *epj = *args++;
    char *djm0 = *args++;
    char *djm = *args++;
    npy_intp s_epj = *steps++;
    npy_intp s_djm0 = *steps++;
    npy_intp s_djm = *steps++;
```
I am not aware of any bad consequences of this re-ordering.