### PR TITLE
Consolidate `erfa.core.STATUS_CODES` definition

### DIFF
--- a/erfa/core.py.templ
+++ b/erfa/core.py.templ
@@ -51,7 +51,9 @@ class ErfaWarning(UserWarning):
 # <---------------------------------Error-handling---------------------------->
 
 
-STATUS_CODES = {}  # populated below before each function that returns an int
+STATUS_CODES = {
+    $status_code_entries
+}
 
 # This is a hard-coded list of status codes that need to be remapped,
 # such as to turn errors into warnings.

--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -234,10 +234,8 @@ class StatusCode(Variable):
         }
         self.can_fail: Final = list(self._statuscodes) != [0]
 
-    def to_python(self) -> str:
-        return "\n".join(
-            ["{", *[f'    {k!r}: "{v}",' for k, v in self._statuscodes.items()], "}"]
-        )
+    def to_python(self) -> list[str]:
+        return ["{", *[f'    {k!r}: "{v}",' for k, v in self._statuscodes.items()], "}"]
 
 
 class Return(Variable):
@@ -515,11 +513,6 @@ class Function(ABC):
     @functools.cached_property
     def to_python(self) -> str:
         lines = []
-        if (
-            isinstance((status_code := self.c_retval), StatusCode)
-            and status_code.can_fail
-        ):
-            lines.append(f'STATUS_CODES["{self.pyname}"] = {status_code.to_python()}')
         if isinstance(self.py_return, ResultTuple):
             lines.append(self.py_return.define())
         lines.append(self.python_wrapper)
@@ -805,6 +798,7 @@ def main(srcdir: Path, templateloc: Path) -> None:
             r"\w+ (\w+)\(.*?\);", (srcdir / "erfa.h").read_text(), flags=re.DOTALL
         )
     ]
+    funcs_sorted_by_name = sorted(funcs, key=lambda f: f.pyname)
 
     constants: list[Constant] = []
     for chunk in (srcdir / "erfam.h").read_text().split("\n\n"):
@@ -825,6 +819,11 @@ def main(srcdir: Path, templateloc: Path) -> None:
             '"ErfaError",',
             '"ErfaWarning",',
             *[f'"{func.pyname}",' for func in funcs],
+        ]),
+        status_code_entries=_indent([
+            f'"{func.pyname}": {_indent(scode.to_python())},'
+            for func in funcs_sorted_by_name
+            if isinstance((scode := func.c_retval), StatusCode) and scode.can_fail
         ]),
         constants="\n".join(constant.define for constant in constants),
         funcs="\n\n\n".join([func.to_python for func in funcs]),
@@ -848,9 +847,7 @@ def main(srcdir: Path, templateloc: Path) -> None:
         templateloc / "tests" / "test_ufunc.py.templ",
         test_functions="\n\n\n".join([
             _indent([f"def test_{tfunc.func.pyname}():", *tfunc.to_python()])
-            for tfunc in sorted(
-                map(create_test_funcs, funcs), key=lambda f: f.func.name
-            )
+            for tfunc in map(create_test_funcs, funcs_sorted_by_name)
         ]),
     )
 


### PR DESCRIPTION
`STATUS_CODES` is the `dict` that contains possible status code values ERFA functions can return together with their descriptions extracted from the ERFA doc comments. On current `main` `erfa_generator` produces a `core.py` file that initializes `STATUS_CODES` as an empty `dict` to which entries are added one function at a time, meaning its contents are spread out across almost 20 000 lines. In this PR `erfa_generator` produces code that creates `STATUS_CODES` in one go. The change is only to how `STATUS_CODES` gets populated, there are no changes to the entries themselves.