### PR TITLE
Improve handling LDBODY array sizes in tests

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -712,8 +712,6 @@ class TestFunction:
 
             # Call of function that is being tested.
             elif self.func.name in line:
-                # correct for LDBODY (complete hack!)
-                line = line.replace('3, b', 'b').replace('n, b', 'b')
                 in_args, out_args = _args_from_func_call(line, self.func)
                 if self.func.c_retval:
                     out_args.append(line.split(" =", 1)[0])
@@ -743,6 +741,9 @@ def _args_from_func_call(line: str, func: Function) -> tuple[list[str], list[str
         arg.strip().removeprefix("&")
         for arg in line.split("(", 1)[1].removesuffix(")").split(",")
     ]
+    for i, elem in enumerate(func.c_args):
+        if elem.ctype == "eraLDBODY":
+            args.pop(i)  # pyerfa does not require array sizes as separate arguments.
     in_args = [
         # convert any C octal integer literals       [
         str(int(arg, 8)) if arg.startswith("0") and arg.isdigit() else arg


### PR DESCRIPTION
The sizes of LDBODY arrays are not known at compile-time, so ERFA C functions require the size to be passed as a separate argument. The ufunc wrappers can look up array sizes at runtime, so they do not have that argument. Therefore, when `erfa_generator` translates ERFA C tests to Python the array size arguments must be removed. On current `main` this is done by replacing sub-strings in the C source code, but that requires making assumptions about variable names and literal values. In this PR the removal is performed without those assumptions.