### PR TITLE
Discard the description of status code 0

### DIFF
--- a/erfa_generator.py
+++ b/erfa_generator.py
@@ -224,18 +224,18 @@ class StatusCode(Variable):
             raise RuntimeError(
                 f"cannot find status code description in {funcname} doc comment"
             )
-        self._statuscodes: Final = {
+        self.descriptons: Final = {
             "else" if code == "else" else int(code): " ".join(
                 line.strip() for line in description.splitlines()
             )
             for code, description in re.findall(
                 r"(-?\w+) = ((?:[^=]+$)+)", status.group(1), re.MULTILINE
             )
+            if code != "0"
         }
-        self.can_fail: Final = list(self._statuscodes) != [0]
 
     def to_python(self) -> list[str]:
-        return ["{", *[f'    {k!r}: "{v}",' for k, v in self._statuscodes.items()], "}"]
+        return ["{", *[f'    {k!r}: "{v}",' for k, v in self.descriptons.items()], "}"]
 
 
 class Return(Variable):
@@ -361,7 +361,7 @@ class Function(ABC):
                 out_args=[arg.name for arg in self.ufunc_return],
             )
         ]
-        if isinstance(self.c_retval, StatusCode) and self.c_retval.can_fail:
+        if isinstance(self.c_retval, StatusCode) and self.c_retval.descriptons:
             lines.append(f'check_errwarn({self.c_retval.name}, "{self.pyname}")')
         lines.extend(
             f"{arg.name} = {arg.name}.view(dt_bytes1)"
@@ -805,7 +805,7 @@ def main(srcdir: Path, templateloc: Path) -> None:
         status_code_entries=_indent([
             f'"{func.pyname}": {_indent(scode.to_python())},'
             for func in funcs_sorted_by_name.values()
-            if isinstance((scode := func.c_retval), StatusCode) and scode.can_fail
+            if isinstance((scode := func.c_retval), StatusCode) and scode.descriptons
         ]),
         constants="\n".join(constant.define for constant in constants),
         funcs="\n\n\n".join([func.to_python for func in funcs]),


### PR DESCRIPTION
Many ERFA functions return a status code which is used by the Python wrappers to raise an error or emit a warning. The error or warning messages are taken from the ERFA C doc comments and stored in a module level dictionary. Status code 0 always means that there were no warnings or errors, so there is no message to display to the user and the descriptions do not have to be stored.

EDIT: The full difference between `erfa/core.py` generated on current `main` and in this PR is
```diff
334d333
<         0: "OK",
341d339
<         0: "OK",
346d343
<         0: "OK",
351d347
<         0: "OK",
356d351
<         0: "OK",
361d355
<         0: "OK",
366d359
<         0: "OK",
370d362
<         0: "OK",
377d368
<         0: "OK",
382d372
<         0: "OK",
393d382
<         0: "OK",
402d390
<         0: "OK",
406d393
<         0: "OK",
410d396
<         0: "OK",
415d400
<         0: "OK",
420d404
<         0: "OK",
425d408
<         0: "OK",
429d411
<         0: "OK",
434d415
<         0: "OK",
439d419
<         0: "OK",
445d424
<         0: "no warnings or errors",
452d430
<         0: "OK",
458d435
<         0: "no warnings or errors",
465d441
<         0: "no warnings",
473d448
<         0: "OK",
477d451
<         0: "OK",
483d456
<         0: "OK",
489d461
<         0: "OK",
495d466
<         0: "OK",
502d472
<         0: "OK",
507d476
<         0: "OK",
512d480
<         0: "OK",
```