### PR TITLE
Require `numpy` >= 2.0

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -121,36 +121,3 @@ jobs:
         python -m pip install --editable .[test]
         (nm -u erfa/ufunc.*.so | grep eraA2af) || exit 1
         (python -c 'import erfa' 2>&1 | grep -n 'too old') > /dev/null && (echo 'liberfa too old, skipping tests'; exit 0) || python -m pytest
-
-
-  build_against_numpy_1:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
-        submodules: true
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        # this is mainly meant to be useful on old or exotic archs
-        # so we use our oldest-supported Python
-        python-version: '3.10'
-    - name: Install build-time dependencies
-      run: |
-        python -m pip install --upgrade setuptools setuptools_scm 'numpy<2.0'
-    - run: python -m pip list
-    - name: Build
-      # using --no-build-isolation allows us to skip pass build-system metadata
-      # from pyproject.toml
-      # In particular this allows us to use an older version of numpy than we
-      # normally require.
-      # building in --editable mode to avoid PYTHONPATH issues
-      run: |
-        python -m pip install --editable . --no-build-isolation
-
-    - name: Check
-      run: python -c "import erfa"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@
   unavoidable ``KeyError``. [gh-234]
 - ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an
   ``ErfaError`` or ``ErfaWarning`` if all its inputs are scalars. [gh-235]
-- ``pyerfa`` now requires ``numpy`` 1.24 or later. [gh-250]
+- ``pyerfa`` now requires ``numpy`` 2.0 or later. [gh-329]
 
 2.0.1.6 (2025-01-27)
 ====================

--- a/erfa/leap_seconds.py
+++ b/erfa/leap_seconds.py
@@ -33,8 +33,6 @@ import numpy as np
 from .core import ErfaWarning
 from .ufunc import dt_eraLEAPSECOND, get_leap_seconds, set_leap_seconds
 
-NUMPY_LT_2_0 = np.__version__.startswith("1.")
-
 
 def __getattr__(name):
     if name == "expires":
@@ -112,8 +110,7 @@ def validate(table):
     if hasattr(table, "__array__"):
         table = table.__array__()[list(dt_eraLEAPSECOND.names)]
 
-    table = np.array(table, dtype=dt_eraLEAPSECOND, ndmin=1,
-                     copy=False if NUMPY_LT_2_0 else None)
+    table = np.array(table, dtype=dt_eraLEAPSECOND, ndmin=1, copy=None)
 
     # Simple sanity checks.
     if table.ndim > 1:

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -22,11 +22,6 @@ that do not support it (e.g., 3.13t)
 #include "erfa.h"
 #include "erfaextra.h"
 
-// Backported NumPy 2 API (can be removed if numpy 2 is required)
-#if NPY_ABI_VERSION < 0x02000000
-#define PyDataType_ELSIZE(descr) ((descr)->elsize)
-#endif
-
 #define MODULE_DOCSTRING \
     "Ufunc wrappers of the ERFA routines.\n\n" \
     "These ufuncs vectorize the ERFA functions assuming structured dtypes\n" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=77.0.0",
     "setuptools_scm>=8.0.0",
-    "numpy>=2.0.0rc1",
+    "numpy>=2.0.0",
 ]
 build-backend = 'setuptools.build_meta'
 
@@ -25,7 +25,7 @@ classifiers = [
 ]
 urls = {Homepage = "https://github.com/liberfa/pyerfa"}
 requires-python = ">=3.10"
-dependencies = ["numpy>=1.24"]
+dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    oldestdeps: numpy==1.24.*
+    oldestdeps: numpy==2.0.*
     devdeps: numpy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
`numpy` < 2.0 has already been supported for a year longer than [SPEC 0](https://scientific-python.org/specs/spec-0000/) requires.