### PR TITLE
Allow more `setuptools-scm` versions for typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ docs = ["sphinx-astropy>=1.3"]
 [dependency-groups]
 typing = [
     "mypy>=1.20.1",
-    # Some code was moved from setuptools-scm 10 to a separate vcs-versioning library,
-    # but vcs-versioning<= 1.1.1 lacks the py.typed marker file (accidentally).
-    "setuptools_scm<10",
+    "setuptools-scm>=8.0.0",
     "types-setuptools>=82.0.0.20260518",
+    # Older vcs-versioning versions lack the py.typed marker file
+    # (accidentally), but it is not needed at all with setuptools-scm < 10.
+    "vcs-versioning>=2.0.1; 'setuptools-scm'>='10'",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Some code that had been in `setuptools-scm` < 10 is now in a separate `vcs-versioning` library. Early versions of the latter lacked the [`py.typed` marker file](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information), so they could not be used for type-checking in downstream packages and the `typing` dependency group had to require `setuptools-scm` < 10 to avoid `vcs-versioning`. This is no longer necessary because `vcs-versioning` >= 2.0.1 does include `py.typed`.