### PR TITLE
Avoid installing `numpy` twice in external liberfa CI job

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -98,7 +98,7 @@ jobs:
             python: '3.10'
             toxenv: test
             toxargs: -v
-            apt_packages: python3-venv python3-pip liberfa-dev python3-numpy
+            apt_packages: python3-venv python3-pip liberfa-dev
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
The external `liberfa` CI job installs `numpy` twice, and the system installation is not used. This is not caused by the recent update of the `numpy` version requirement, as evidenced by logs that predate that change: https://github.com/liberfa/pyerfa/actions/runs/33149513378/job/98777985559#step:5:27