### PR TITLE
workflows: fetch tags from origin, use uv, add riscv64 builds

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm, ubuntu-24.04-riscv]
         python: ['3']
         toxenv: [test]
         toxargs: [-v]

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
-        python: ['3.x']
+        python: ['3']
         toxenv: [test]
         toxargs: [-v]
 
@@ -51,7 +51,7 @@ jobs:
 
           - name: Documentation build
             os: ubuntu-22.04
-            python: '3.10'
+            python: '3'
             toxenv: build_docs
             toxargs: -v
             apt_packages: graphviz
@@ -68,10 +68,10 @@ jobs:
       # don't carry tags added to liberfa/pyerfa after they were created.
       run: git fetch --tags --no-recurse-submodules https://github.com/liberfa/pyerfa.git
     - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
+        activate-environment: true
         python-version: ${{ matrix.python }}
-        allow-prereleases: true
     - name: Install APT packages
       if: matrix.apt_packages
       run: sudo apt-get install ${{ matrix.apt_packages }}
@@ -79,10 +79,10 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install autoconf automake
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox
+      run: uv pip install --upgrade tox tox-uv
     - name: Run tests
       run: |
-        pip freeze
+        uv pip list
         tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
 
   tests_external_liberfa:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -63,6 +63,10 @@ jobs:
         fetch-depth: 0
         submodules: true
         persist-credentials: false
+    - name: Fetch tags from upstream
+      # setuptools_scm needs the release tags to compute the version; forks
+      # don't carry tags added to liberfa/pyerfa after they were created.
+      run: git fetch --tags --no-recurse-submodules https://github.com/liberfa/pyerfa.git
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
@@ -106,6 +110,10 @@ jobs:
         fetch-depth: 0
         submodules: true
         persist-credentials: false
+    - name: Fetch tags from upstream
+      # setuptools_scm needs the release tags to compute the version; forks
+      # don't carry tags added to liberfa/pyerfa after they were created.
+      run: git fetch --tags --no-recurse-submodules https://github.com/liberfa/pyerfa.git
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
     - name: Install APT packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       # the latest stable versions of all other build-time dependencies.
       env: |
         CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre setuptools setuptools_scm numpy') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
+        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'uv; args: --no-build-isolation') || 'build[uv]' }}'
 
       test_extras: test
       test_command: pytest --pyargs erfa

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
         - cp3*-musllinux_x86_64
         - cp3*-manylinux_aarch64
         - pp3*-manylinux_x86_64
+        # RISC-V wheels - built natively on RISE's riscv64 runners, no QEMU.
+        - target: cp3*-manylinux_riscv64
+          runs-on: ubuntu-24.04-riscv
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         - cp3*macosx_x86_64
         - cp3*macosx_arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,10 @@ files = [
 
 [tool.uv]
 prerelease = "allow"
+# Some dependencies don't yet publish riscv64 wheels to PyPI; fall back to
+# RISE's index, which does, instead of building from sdist.
+index-strategy = "unsafe-best-match"
+
+[[tool.uv.index]]
+name = "riseproject"
+url = "https://pypi.riseproject.dev/simple/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,6 @@ files = [
     "setup.py",
     "erfa/tests/test_ufunc.py"
 ]
+
+[tool.uv]
+prerelease = "allow"


### PR DESCRIPTION
Make use of RISE's Native RISC-V Runners to build pyerfa for riscv64. This requires enabling them for the repository as a GitHub Application. More info regarding enabling them is available here: https://riscv-runners.riseproject.dev/

This includes a workflow overhaul to use the uv tool, which is generally faster and supports more architectures. It also begins with a fix for a tag fetching issue I ran into while testing.

I tried a test run on my fork. You can review the results here: https://github.com/threexc/pyerfa/pull/1

This is being done on behalf of [RISE](https://riseproject.dev/), using the [RISC-V Wheels](https://stanfromireland.github.io/riscv-wheels/) dashboard to track upstream support for the Python ecosystem.