### PR TITLE
Drop support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -39,7 +39,7 @@ jobs:
 
           - name: Test with oldest supported versions of our dependencies
             os: ubuntu-22.04
-            python: '3.10'
+            python: '3.11'
             toxenv: test-oldestdeps
             toxargs: -v
 
@@ -51,7 +51,7 @@ jobs:
 
           - name: Documentation build
             os: ubuntu-22.04
-            python: '3.10'
+            python: '3.11'
             toxenv: build_docs
             toxargs: -v
             apt_packages: graphviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ====================
 - Let multi-output functions now return a ``namedtuple`` so that
   the various results can be accessed by attribute. [gh-176]
-- ``pyerfa`` now requires Python 3.10 or later. [gh-185]
+- ``pyerfa`` now requires Python 3.11 or later. [gh-335]
 - The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
   unavoidable ``KeyError``. [gh-234]
 - ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 urls = {Homepage = "https://github.com/liberfa/pyerfa"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
 
@@ -73,7 +73,6 @@ xfail_strict = true
 enable = ["pypy"]
 skip = [
     "cp314t-*",
-    "cp310-win_arm64",
 ]
 
 [tool.ruff.lint]

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
 define_macros: list[tuple[str, str | None]] = []
 options = {}
 if USE_PY_LIMITED_API:
-    define_macros.append(("Py_LIMITED_API", "0x30a00f0"))
-    options["bdist_wheel"] = {"py_limited_api": "cp310"}
+    define_macros.append(("Py_LIMITED_API", "0x30b00f0"))
+    options["bdist_wheel"] = {"py_limited_api": "cp311"}
 
 
 def get_liberfa_versions(


### PR DESCRIPTION
~~[Python 3.10 is very close to its end-of-life](https://devguide.python.org/versions/), so dropping support for it is not controversial.~~

~~The end-of-life for Python 3.11 is still a year away, but [PEP 695 – Type Parameter Syntax](https://peps.python.org/pep-0695/) makes dropping support for it very appealing and supporting it is not required by [SPEC 0](https://scientific-python.org/specs/spec-0000/).~~

EDIT: Dropping support for even just Python 3.10 requires updating `erfa/ufunc.c`. I don't know C, so someone else is going to have to do that.