### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -39,7 +39,7 @@ jobs:
 
           - name: Test with oldest supported versions of our dependencies
             os: ubuntu-22.04
-            python: '3.10'
+            python: '3.11'
             toxenv: test-oldestdeps
             toxargs: -v
 
@@ -51,7 +51,7 @@ jobs:
 
           - name: Documentation build
             os: ubuntu-22.04
-            python: '3.10'
+            python: '3.11'
             toxenv: build_docs
             toxargs: -v
             apt_packages: graphviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ====================
 - Let multi-output functions now return a ``namedtuple`` so that
   the various results can be accessed by attribute. [gh-176]
-- ``pyerfa`` now requires Python 3.10 or later. [gh-185]
+- ``pyerfa`` now requires Python 3.11 or later. [gh-337]
 - The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
   unavoidable ``KeyError``. [gh-234]
 - ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -265,7 +265,7 @@ ensure_dtype_nbo(PyArray_Descr *type)
 {
     /* MHvK: changed from PyArray_ISNBO(type->byteorder) */
     if (PyDataType_ISNOTSWAPPED(type)) {
-        Py_INCREF(type);
+        Py_INCREF((PyObject*)(type));
         return type;
     }
     else {
@@ -293,7 +293,7 @@ set_ufunc_loop_data_types(PyUFuncObject *self, PyArrayObject **op,
     for (i = 0; i < nop; ++i) {
         if (dtypes != NULL) {
             out_dtypes[i] = dtypes[i];
-            Py_XINCREF(out_dtypes[i]);
+            Py_XINCREF((PyObject*)(out_dtypes[i]));
         /*
          * Copy the dtype from 'op' if the type_num matches,
          * to preserve metadata.
@@ -445,7 +445,7 @@ get_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *NPY_UNUSED(args)) {
         return NULL;
     }
     /* Allocate an array to hold them */
-    Py_INCREF(dt_eraLEAPSECOND);
+    Py_INCREF((PyObject*)(dt_eraLEAPSECOND));
     array = (PyArrayObject *)PyArray_NewFromDescr(
         &PyArray_Type, dt_eraLEAPSECOND, 1, &count, NULL, NULL, 0, NULL);
     if (array == NULL) {
@@ -471,7 +471,7 @@ set_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *args) {
          * Ensure a copy is made so one cannot change the data by changing
          * the input array.
          */
-        Py_INCREF(dt_eraLEAPSECOND);
+        Py_INCREF((PyObject*)(dt_eraLEAPSECOND));
         array = (PyArrayObject *)PyArray_FromAny(leap_seconds, dt_eraLEAPSECOND,
                     1, 1, (NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY), NULL);
         if (array == NULL) {
@@ -718,20 +718,20 @@ fail:
     Py_XDECREF(dtype_def);
     Py_XDECREF(erfa_version);
     Py_XDECREF(sofa_version);
-    Py_XDECREF(ufunc);
+    Py_XDECREF((PyObject*)(ufunc));
 
 decref:
-    Py_XDECREF(dt_double);
-    Py_XDECREF(dt_int);
-    Py_XDECREF(dt_pv);
-    Py_XDECREF(dt_pvdpv);
-    Py_XDECREF(dt_ymdf);
-    Py_XDECREF(dt_hmsf);
-    Py_XDECREF(dt_dmsf);
-    Py_XDECREF(dt_sign);
-    Py_XDECREF(dt_type);
-    Py_XDECREF(dt_eraASTROM);
-    Py_XDECREF(dt_eraLDBODY);
-    Py_XDECREF(dt_eraLEAPSECOND);
+    Py_XDECREF((PyObject*)(dt_double));
+    Py_XDECREF((PyObject*)(dt_int));
+    Py_XDECREF((PyObject*)(dt_pv));
+    Py_XDECREF((PyObject*)(dt_pvdpv));
+    Py_XDECREF((PyObject*)(dt_ymdf));
+    Py_XDECREF((PyObject*)(dt_hmsf));
+    Py_XDECREF((PyObject*)(dt_dmsf));
+    Py_XDECREF((PyObject*)(dt_sign));
+    Py_XDECREF((PyObject*)(dt_type));
+    Py_XDECREF((PyObject*)(dt_eraASTROM));
+    Py_XDECREF((PyObject*)(dt_eraLDBODY));
+    Py_XDECREF((PyObject*)(dt_eraLEAPSECOND));
     return m;
 }

--- a/erfa/ufunc.c.templ
+++ b/erfa/ufunc.c.templ
@@ -16,6 +16,8 @@ that do not support it (e.g., 3.13t)
 */
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <stdlib.h>
+#include <string.h>
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 urls = {Homepage = "https://github.com/liberfa/pyerfa"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
 
@@ -73,7 +73,6 @@ xfail_strict = true
 enable = ["pypy"]
 skip = [
     "cp314t-*",
-    "cp310-win_arm64",
 ]
 
 [tool.ruff.lint]

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
 define_macros: list[tuple[str, str | None]] = []
 options = {}
 if USE_PY_LIMITED_API:
-    define_macros.append(("Py_LIMITED_API", "0x30a00f0"))
-    options["bdist_wheel"] = {"py_limited_api": "cp310"}
+    define_macros.append(("Py_LIMITED_API", "0x30b0000"))
+    options["bdist_wheel"] = {"py_limited_api": "cp311"}
 
 
 def get_liberfa_versions(


### PR DESCRIPTION
[Python 3.10 is only a month or so away from its end-of-life](https://devguide.python.org/versions/), so there is no reason to keep supporting it.

Upgrading from Python 3.10 limited C API to Python 3.11 limited C API is not trivial for two reasons. The first is that `Python.h` no longer includes `<stdlib.h>` and `<string.h>` with limited C API (see the [Python 3.11 change log](https://docs.python.org/3.11/whatsnew/3.11.html#whatsnew311-c-api-porting)), so `ufunc.c` needs to include them itself (the former for `malloc()` and `free()` and the latter for `memcpy()`). The second reason is because of [PEP 670 – Convert macros to functions in the Python C API](https://peps.python.org/pep-0670/). Some macros that performed casts themselves were replaced with functions that in the limited C API do not perform casts, so now the casts have to be performed explicitly by `ufunc.c`.

I would also like to drop support for Python 3.11, but my first attempt (#335) ran into problems, so now I think it's better to handle one Python version at a time.

DISCLAIMER: I know neither Python C API in particular nor C in general, I just followed what I think the compiler errors and warnings in #335 suggested.