### PR TITLE
Drop support for 3.11

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -39,7 +39,7 @@ jobs:
 
           - name: Test with oldest supported versions of our dependencies
             os: ubuntu-22.04
-            python: '3.11'
+            python: '3.12'
             toxenv: test-oldestdeps
             toxargs: -v
 
@@ -51,7 +51,7 @@ jobs:
 
           - name: Documentation build
             os: ubuntu-22.04
-            python: '3.11'
+            python: '3.12'
             toxenv: build_docs
             toxargs: -v
             apt_packages: graphviz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,16 +40,12 @@ jobs:
         - cp3*-manylinux_x86_64
         - cp3*-musllinux_x86_64
         - cp3*-manylinux_aarch64
-        - pp3*-manylinux_x86_64
         # MacOS X wheels - we deliberately do not build universal2 wheels.
         - cp3*macosx_x86_64
         - cp3*macosx_arm64
-        - pp3*-macosx_x86_64
-        - pp3*-macosx_arm64
         # Windows wheels
         - cp3*-win_amd64
         - cp3*-win_arm64
-        - pp3*-win_amd64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ====================
 - Let multi-output functions now return a ``namedtuple`` so that
   the various results can be accessed by attribute. [gh-176]
-- ``pyerfa`` now requires Python 3.11 or later. [gh-337]
+- ``pyerfa`` now requires Python 3.12 or later. [gh-338]
 - The ``erfa.tpors()`` and ``erfa.tporv()`` functions no longer raise an
   unavoidable ``KeyError``. [gh-234]
 - ``erfa.cal2jd()`` no longer raises an unexpected ``TypeError`` instead of an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 urls = {Homepage = "https://github.com/liberfa/pyerfa"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = ["numpy>=2.0.0"]
 dynamic = ["version"]
 
@@ -70,7 +70,6 @@ addopts = "--doctest-rst"
 xfail_strict = true
 
 [tool.cibuildwheel]
-enable = ["pypy"]
 skip = [
     "cp314t-*",
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
 define_macros: list[tuple[str, str | None]] = []
 options = {}
 if USE_PY_LIMITED_API:
-    define_macros.append(("Py_LIMITED_API", "0x30b0000"))
-    options["bdist_wheel"] = {"py_limited_api": "cp311"}
+    define_macros.append(("Py_LIMITED_API", "0x30c0000"))
+    options["bdist_wheel"] = {"py_limited_api": "cp312"}
 
 
 def get_liberfa_versions(


### PR DESCRIPTION
[SPEC 0](https://scientific-python.org/specs/spec-0000/) allowed dropping support for Python 3.11 already a year ago and it is no longer supported by the development versions of neither `numpy` (the most important upstream package) nor `astropy` (the most important downstream package). Requiring Python 3.12 is appealing because that is the first Python version that implemented [PEP 695 – Type Parameter Syntax](https://peps.python.org/pep-0695/).